### PR TITLE
Made env vars configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ We also support the aliases of `BREAKING`, `FEATURE`, and `FIX`.
 `pr-bumper` currently only supports pull requets on [GitHub](github.com),
 but support is also planned for [Bitbucket Server](https://bitbucket.org/product/server).
 
+It is also optimized to work with [Travis CI](https://travis-ci.org) out-of-the box, but support is also
+planned for [TeamCity](https://www.jetbrains.com/teamcity/)
+
 ## Installation
 
 ```
@@ -50,7 +53,20 @@ npm install pr-bumper
 ```
 
 ## Usage
-`pr-bumper` is optimized to work with Travis CI.
+You can check for the existence of a valid directive in the current (open) pr (during the pr build) by using
+
+```
+pr-bumper check
+```
+
+You can perform the automated bump in the merge build by using:
+
+```
+pr-bumper bump
+```
+
+## Travis CI
+`pr-bumper` is optimized to work with Travis CI and by defaults uses Travis CI environment variables for configuration.
 
 Add the following snippets to your `.travis.yml` file to integrate `pr-bumper`
 
@@ -74,3 +90,19 @@ comments on your PRs, as well as allow it to automatically version-bump and git 
 them.
 
 The `branches` section tells travis to skip the `v#.#.#` branches (or tags)
+
+Before `pr-bumper` can push commits and tags back to your repository however, you need to set up authentication.
+
+You'll need a [Personal Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
+to let Travis push commits to GitHub. Granting `public_repo` access is sufficient for the token you need to use.
+The `GITHUB_TOKEN` environment variable needs to be set with your token.
+Since you're token should be kept secret, you'll want to encrypt it.
+
+You can do so by using the [Travis Client](https://github.com/travis-ci/travis.rb) to `travis encrypt` your token.
+
+First, you'll need to authenticate with `travis` (you can use the same token for that)
+
+```
+travis login --github-token your-token-goes-here
+travis encrypt GITHUB_TOKEN=your-token-goes-here --add
+```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,8 +11,6 @@ let cmd = ''
 
 program
   .version(pkgJson.version)
-  .option('-o, --owner [value]', 'The repository owner/project')
-  .option('-r, --repo [value]', 'The repository name')
 
 program
   .command('bump')
@@ -28,19 +26,10 @@ program
 
 program.parse(process.argv)
 
-let travisOwner
-let travisRepo
-if (process.env.TRAVIS_REPO_SLUG) {
-  const parts = process.env.TRAVIS_REPO_SLUG.split('/')
-  travisOwner = parts[0]
-  travisRepo = parts[1]
-}
+const config = utils.getConfig()
 
-const owner = program.owner || travisOwner
-const repo = program.repo || travisRepo
-
-const vcs = new lib.GitHub(owner, repo)
-const bumper = new lib.Bumper(vcs)
+const vcs = new lib.GitHub(config.owner, config.repo)
+const bumper = new lib.Bumper(vcs, config)
 
 switch (cmd) {
   case 'bump':

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,7 +26,7 @@ program
 
 program.parse(process.argv)
 
-const config = utils.getConfig()
+const config = lib.utils.getConfig()
 
 const vcs = new lib.GitHub(config.owner, config.repo)
 const bumper = new lib.Bumper(vcs, config)

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -14,9 +14,11 @@ class Bumper {
 
   /**
    * @param {Vcs} vcs - the vcs instance to use
+   * @param {Config} config - the bumper config object
    */
-  constructor (vcs) {
+  constructor (vcs, config) {
     this.vcs = vcs
+    this.config = config
   }
 
   /**
@@ -24,7 +26,7 @@ class Bumper {
    * @returns {Promise} a promise resolved when complete or rejected on error
    */
   check () {
-    if (process.env.TRAVIS_PULL_REQUEST === 'false') {
+    if (!this.config.isPr) {
       console.log(`${pkgJson.name}:  Not a PR build, skipping check`)
       return Promise.resolve()
     } else {

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -39,12 +39,13 @@ class Bumper {
 
   bump () {
     const vcs = this.vcs
+    const config = this.config
     return this.getMergedPrScope()
       .then((scope) => {
         return utils.bumpVersion(scope)
       })
       .then(() => {
-        return utils.commitChanges()
+        return utils.commitChanges(config)
       })
       .then(() => {
         return vcs.push()
@@ -57,7 +58,7 @@ class Bumper {
    */
   getOpenPrScope () {
     const vcs = this.vcs
-    return utils.getSha()
+    return utils.getSha(this.config)
       .then((sha) => {
         return vcs.getOpenPrForSha(sha)
       })
@@ -72,7 +73,7 @@ class Bumper {
    */
   getMergedPrScope () {
     const vcs = this.vcs
-    return utils.getSha()
+    return utils.getSha(this.config)
       .then((sha) => {
         return vcs.getClosedPrForSha(sha)
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   Bumper: require('./bumper'),
-  GitHub: require('./github')
+  GitHub: require('./github'),
+  utils: require('./utils')
 }

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -1,4 +1,26 @@
 /**
+ * The options that can be defined in .pr-bumper.json
+ * @typedef Options
+ * @param {String} [owner] - the organization/user/project that owns the repository (overriding repoSlugEnv)
+ * @param {String} [repo] - the name of the repository (overriding repoSlugEnv)
+ * @param {String} [repoSlugEnv=TRAVIS_REPO_SLUG] - env var for repo slug "owner/repo"
+ * @param {String} [commitEnv=TRAVIS_COMMIT] - env var for current commit hash
+ * @param {String} [prEnv=TRAVIS_PULL_REQUEST] - env var for current pr # (or 'false')
+ * @param {String} [buildNumberEnv=TRAVIS_BUILD_NUMBER] - env var for current build #
+ * @param {String}
+ */
+
+/**
+ * The configuration object built from the options
+ * @typedef Config
+ * @param {String} owner - the organization/user/project that owns the repository
+ * @param {String} repo - the name of the repository
+ * @param {String} commitSha - the sha of the current commit
+ * @param {Boolean} isPr - true if pull request build
+ * @param {String} buildNumber - the CI build #
+ */
+
+/**
  * The representation of a commit within the GitHub API
  * @typedef GitHubCommit
  * @param {String} sha - the SHA hash for the commit

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,12 +2,69 @@
 
 require('./typedefs')
 
+const path = require('path')
+const __ = require('lodash')
 const versiony = require('versiony')
 const Promise = require('promise')
 const cpExec = require('child_process').exec
 const exec = Promise.denodeify(cpExec)
 
 const utils = {
+
+  /**
+   * Get the Options from either the `.pr-bumper.json` file or the defaults
+   * @returns {Options} the options object
+   */
+  getOptions () {
+    let options = {}
+    try {
+      options = require(path.join(process.cwd(), '.pr-bumper.json'))
+    } catch (e) {
+      console.log('No .pr-bumper.json found, using defaults')
+    }
+    __.defaults(options, {
+      repoSlugEnv: 'TRAVIS_REPO_SLUG',
+      commitEnv: 'TRAVIS_COMMIT',
+      prEnv: 'TRAVIS_PULL_REQUEST'
+      buildNumberEnv: 'TRAVIS_BUILD_NUMBER'
+    })
+
+    return options
+  },
+
+  /**
+   * Use an Options object to generate the Config
+   * @param {Options} [options] - the options for what environment variables to use
+   * @returns {Config} the config object
+   */
+  getConfig (options) {
+    options = options || this.getOptions()
+
+    let owner = options.owner
+    let repo = options.repo
+    const slug = process.env[options.repoSlugEnv]
+    let parts = ['', '']
+
+    if (slug) {
+      parts = slug.split('/')
+    }
+
+    if (!owner) {
+      owner = parts[0]
+    }
+
+    if (!repo) {
+      repo = parts[1]
+    }
+
+    return {
+      owner,
+      repo,
+      commitSha: process.env[options.commitEnv],
+      isPr: process.env[options.prEnv] !== 'false',
+      buildNumber: process.env[options.buildNumberEnv]
+    }
+  }
 
   /**
    * Make sure scope is one of 'patch', 'minor', 'major' (or their aliases)
@@ -40,12 +97,13 @@ const utils = {
   /**
    * If we are in a PR build, just grab the sha from env, if not
    * take a look at the git history (one before the merge we're handling) and find that PR
+   * @param {Config} config - the config object
    * @returns {String} the sha of the current commit
    */
-  getSha () {
-    if (process.env.TRAVIS_PULL_REQUEST && (process.env.TRAVIS_PULL_REQUEST !== 'false')) {
-      console.log(`Using TRAVIS_COMMIT [${process.env.TRAVIS_COMMIT}] for sha`)
-      return Promise.resolve(process.env.TRAVIS_COMMIT)
+  getSha (config) {
+    if (config.isPr) {
+      console.log(`Using CI commit sha [${config.commitSha}]`)
+      return Promise.resolve(config.commitSha)
     }
 
     return exec('git log -1 --skip=1 --format="%H"').then((stdout) => {
@@ -113,11 +171,10 @@ const utils = {
 
   /**
    * Bump the version in package.json with the given scope
+   * @param {Config} config - the config object
    * @returns {Promise} - a promise resolved with the results of the git commands
    */
-  commitChanges () {
-    // TODO: make this more configurable
-    const buildNumber = process.env.TRAVIS_BUILD_NUMBER
+  commitChanges (config) {
 
     return exec('git config --global user.email "travis.ci.ciena@gmail.com"')
       .then(() => {
@@ -131,14 +188,14 @@ const utils = {
         return exec(`git add package.json`)
       })
       .then(() => {
-        return exec(`git commit -m "Automated version bump [ci skip]" -m "From CI build ${buildNumber}"`)
+        return exec(`git commit -m "Automated version bump [ci skip]" -m "From CI build ${config.buildNumber}"`)
       })
       .then(() => {
         return exec(`node -e "console.log(require('./package.json').version)"`)
       })
       .then((stdout) => {
         const name = stdout.replace('\n', '')
-        return exec(`git tag v${name} -a -m "Generated tag from CI build ${buildNumber}"`)
+        return exec(`git tag v${name} -a -m "Generated tag from CI build ${config.buildNumber}"`)
       })
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ const utils = {
     __.defaults(options, {
       repoSlugEnv: 'TRAVIS_REPO_SLUG',
       commitEnv: 'TRAVIS_COMMIT',
-      prEnv: 'TRAVIS_PULL_REQUEST'
+      prEnv: 'TRAVIS_PULL_REQUEST',
       buildNumberEnv: 'TRAVIS_BUILD_NUMBER'
     })
 
@@ -64,7 +64,7 @@ const utils = {
       isPr: process.env[options.prEnv] !== 'false',
       buildNumber: process.env[options.buildNumberEnv]
     }
-  }
+  },
 
   /**
    * Make sure scope is one of 'patch', 'minor', 'major' (or their aliases)
@@ -175,7 +175,6 @@ const utils = {
    * @returns {Promise} - a promise resolved with the results of the git commands
    */
   commitChanges (config) {
-
     return exec('git config --global user.email "travis.ci.ciena@gmail.com"')
       .then(() => {
         return exec('git config --global user.name "Travis CI"')


### PR DESCRIPTION
By default, we still use the Travis env vars, but now
you can override that with a `.pr-bumper.json` file.
This is a new #feature#