### PR TITLE
Fix for #26 by reading PR # from git commit

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -73,10 +73,7 @@ class Bumper {
    */
   getMergedPrScope () {
     const vcs = this.vcs
-    return utils.getSha(this.config, vcs)
-      .then((sha) => {
-        return vcs.getClosedPrForSha(sha)
-      })
+    return utils.getLastPr(this.config, vcs)
       .then((pr) => {
         return utils.getScopeForPr(pr)
       })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,6 +118,20 @@ const utils = {
   },
 
   /**
+   * Grab the most recent PR
+   * @param {Config} config - the config object
+   * @param {Github} vcs - VCS interface
+   * @returns {Promise} a promise resolved with the most recent PR
+   */
+  getLastPr (config, vcs) {
+    return exec(`git log -50 --oneline | grep -m 1 "Merge pull request" | awk '{print $5;}'`).then((stdout) => {
+      const prNumber = stdout.replace('#', '')
+      console.log(`Fetching PR [${prNumber}]`)
+      return vcs.getPr(prNumber)
+    })
+  },
+
+  /**
    * Extract the scope string ('patch', 'minor', 'major') from the PR object
    * @param {PullRequest} pr - the PR object
    * @returns {String} the scope of the PR (from the pr description)


### PR DESCRIPTION
Instead of assuming that the commit immediately before the merge commit
is the one that represents the PR, pull the PR# from the merge commit
description.

This is a #fix#