### PR TITLE
Add changelog functionality

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -45,9 +45,12 @@ class Bumper {
   bump () {
     const vcs = this.vcs
     const config = this.config
-    return this.getMergedPrScope()
-      .then((scope) => {
-        return utils.bumpVersion(scope, 'package.json')
+    return this.getMergedPrInfo()
+      .then((info) => {
+        return utils.bumpVersion(info, 'package.json')
+      })
+      .then((info) => {
+        return utils.prependChangelog(info, 'CHANGELOG.md')
       })
       .then(() => {
         return utils.commitChanges(config)
@@ -76,11 +79,14 @@ class Bumper {
    * Get the PR scope for the current (merged) pull request
    * @returns {Promise} a promise - resolved with a String scope of the PR or rejected if no valid scope found
    */
-  getMergedPrScope () {
+  getMergedPrInfo () {
     const vcs = this.vcs
     return utils.getLastPr(this.config, vcs)
       .then((pr) => {
-        return utils.getScopeForPr(pr)
+        return {
+          scope: utils.getScopeForPr(pr),
+          changelog: utils.getChangelogForPr(pr)
+        }
       })
   }
 }

--- a/lib/github.js
+++ b/lib/github.js
@@ -139,7 +139,7 @@ class GitHub {
     // is introduced here and exec errors out.
     return exec(`git remote add my-origin https://${ghToken}@github.com/${config.owner}/${config.repo}`)
       .then(() => {
-        return exec(`git push my-origin my-master:refs/heads/master --tags`)
+        return exec('git push my-origin my-master:refs/heads/master --tags')
       })
   }
 }

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -49,6 +49,15 @@
  */
 
 /**
+ * Generic Pull Request info (used for updating package.json and CHANGELOG.md files)
+ *
+ * @typedef PrInfo
+ * @property {String} scope - the scope of the PR
+ * @property {String} version - the new version after bumping based on scope
+ * @property {String} changelog - the changelog text
+ */
+
+/**
  * A Promise that will be resolved with a PullRequest
  *
  * @typedef PrPromise

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,9 +7,11 @@ const __ = require('lodash')
 const versiony = require('versiony')
 const Promise = require('promise')
 const cpExec = require('child_process').exec
+const prependFile = require('prepend-file')
 
 // using let so it can be rewired in the test
 let exec = Promise.denodeify(cpExec)
+let prepend = Promise.denodeify(prependFile)
 
 const logger = require('./logger')
 
@@ -161,13 +163,30 @@ const utils = {
   },
 
   /**
-   * Bump the version in package.json with the given scope
-   * @param {String} scope - the scope of the version bump (major, minor, patch)
-   * @param {String} pkgJsonFile - the full file path to the package.json to bump
+   * Extract the changelog string from the PR object
+   * @param {PullRequest} pr - the PR object
+   * @returns {String} the changelog of the PR (from the pr description, if one exists, else '')
    */
-  bumpVersion (scope, pkgJsonFile) {
+  getChangelogForPr (pr) {
+    const lines = pr.description.split('\n')
+    const index = lines.indexOf('# CHANGELOG')
+    if (index < 0) {
+      return 'No CHANGELOG section found in Pull Request description.\n' +
+             'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`'
+    } else {
+      return lines.slice(index + 1).join('\n')
+    }
+  },
+
+  /**
+   * Bump the version in package.json with the given scope
+   * @param {PrInfo} info - the pr info
+   * @param {String} pkgJsonFile - the full file path to the package.json to bump
+   * @returns {PrInfo} the pr info object passed in
+   */
+  bumpVersion (info, pkgJsonFile) {
     const v = versiony.from(pkgJsonFile).indent(' '.repeat(2))
-    switch (scope) {
+    switch (info.scope) {
       case 'patch':
         v.patch()
         break
@@ -181,10 +200,23 @@ const utils = {
         break
 
       default:
-        throw new Error(`bumpVersion: Invalid scope [${scope}]`)
+        throw new Error(`bumpVersion: Invalid scope [${info.scope}]`)
     }
 
-    v.to(pkgJsonFile).end()
+    const versionInfo = v.to(pkgJsonFile).end()
+    info.version = versionInfo.version
+    return info
+  },
+
+  /**
+   * Prepend the changelog text from the PrInfo into the
+   * @param {PrInfo} info - the pr info
+   * @param {String} changelogFile - the full file path to the CHANGELOG.md file to bump
+   * @returns {Promise} - a promise resolved when changelog has been prepended
+   */
+  prependChangelog (info, changelogFile) {
+    const data = `# ${info.version}\n${info.changelog}`
+    return prepend(changelogFile, data)
   },
 
   /**
@@ -202,13 +234,13 @@ const utils = {
       })
       .then(() => {
         // TODO: make this more configurable? (what's being bumped that is)
-        return exec(`git add package.json`)
+        return exec('git add package.json CHANGELOG.md')
       })
       .then(() => {
         return exec(`git commit -m "Automated version bump [ci skip]" -m "From CI build ${config.buildNumber}"`)
       })
       .then(() => {
-        return exec(`node -e "console.log(require('./package.json').version)"`)
+        return exec('node -e "console.log(require(\'./package.json\').version)"')
       })
       .then((stdout) => {
         const name = stdout.replace('\n', '')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bump the version of a package based on a GitHub Pull Request",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint *.js bin lib tests",
     "test": "npm run-script lint && npm run-script utest",
     "utest": "istanbul cover _mocha tests"
   },
@@ -35,13 +35,14 @@
     "commander": "^2.9.0",
     "lodash": "^4.0.1",
     "node-fetch": "^1.3.3",
+    "prepend-file": "^1.3.0",
     "promise": "^7.1.1",
     "versiony": "^1.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
-    "eslint-config-frost-standard": "^0.1.4",
+    "eslint": "^2.9.0",
+    "eslint-config-frost-standard": "^2.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "rewire": "^2.5.1",


### PR DESCRIPTION
This #feature# introduces the ability to include changelog info in your PR description.

# CHANGELOG
Added ability to maintain a `CHANGELOG.md` file automatically via Pull Requests. Whenever `pr-bumper` runs on a merge build, it now not only bumps `package.json`, but also prepends some content into `CHANGELOG.md` at the root of the repository. If that file doesn't exist, it's created.

## What is added to `CHANGELOG.md`?
`pr-bumper` will always add a new section at the top of the `CHANGELOG.md` file with new version (after the bump), for instance, if `pr-bumper` just applied a `minor` bump to a package at version `1.2.3`, the new section in `CHANGELOG.md` would be `# 1.3.0`. What goes under that section depends on what is in the PR Description. If there is a section that is exactly `# CHANGELOG`, everything below that is put into the new section. If there is no `# CHANGELOG` section in the description, some filler text is placed in the `CHANGELOG.md` giving instructions on how to have that section populated automatically by `pr-bumper` in the future. 