### PR TITLE
Properly handle carriage returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # 0.4.0
-No CHANGELOG section found in Pull Request description.
-Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`
+Added ability to maintain a `CHANGELOG.md` file automatically via Pull Requests. Whenever `pr-bumper` runs on a merge build, it now not only bumps `package.json`, but also prepends some content into `CHANGELOG.md` at the root of the repository. If that file doesn't exist, it's created.
+
+## What is added to `CHANGELOG.md`?
+`pr-bumper` will always add a new section at the top of the `CHANGELOG.md` file with new version (after the bump), for instance, if `pr-bumper` just applied a `minor` bump to a package at version `1.2.3`, the new section in `CHANGELOG.md` would be `# 1.3.0`. What goes under that section depends on what is in the PR Description. If there is a section that is exactly `# CHANGELOG`, everything below that is put into the new section. If there is no `# CHANGELOG` section in the description, some filler text is placed in the `CHANGELOG.md` giving instructions on how to have that section populated automatically by `pr-bumper` in the future.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,33 @@ let prepend = Promise.denodeify(prependFile)
 
 const logger = require('./logger')
 
+/**
+ * Given a PR description, find the index of the # CHANGELOG section
+ * @param {String[]} lines - lines in the pr description
+ * @returns {Number} the index of the # CHANGELOG section (or -1)
+ * @throws Error if there is more than one matching line
+ */
+function getChangelogSectionIndex (lines) {
+  const validSectionHeaders = [
+    '#changelog',
+    '# changelog'
+  ]
+
+  let index = -1
+  for (let i = 0; i < lines.length; i++) {
+    const processedLine = lines[i].trim().toLowerCase()
+    console.log(`processedLine: [${processedLine}]`)
+    if (validSectionHeaders.indexOf(processedLine) !== -1) {
+      if (index !== -1) {
+        throw new Error(`Multiple changelog sections found. Line ${index + 1} and line ${i + 1}.`)
+      }
+      index = i
+    }
+  }
+
+  return index
+}
+
 const utils = {
   /**
    * Get the Options from either the `.pr-bumper.json` file or the defaults
@@ -168,14 +195,25 @@ const utils = {
    * @returns {String} the changelog of the PR (from the pr description, if one exists, else '')
    */
   getChangelogForPr (pr) {
+    const defaultMsg = 'No CHANGELOG section found in Pull Request description.\n' +
+      'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`'
+
     const lines = pr.description.split('\n')
-    const index = lines.indexOf('# CHANGELOG')
-    if (index < 0) {
-      return 'No CHANGELOG section found in Pull Request description.\n' +
-             'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`'
-    } else {
-      return lines.slice(index + 1).join('\n')
+    let index = -1
+    let changelog = ''
+    try {
+      index = getChangelogSectionIndex(lines)
+    } catch (e) {
+      return `${defaultMsg}\n${e.message}`
     }
+
+    if (index < 0) {
+      changelog = defaultMsg
+    } else {
+      changelog = lines.slice(index + 1).join('\n')
+    }
+
+    return changelog
   },
 
   /**

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -373,9 +373,33 @@ describe('utils', () => {
       })
     })
 
+    describe('when multiple changelog sections are present', () => {
+      beforeEach(() => {
+        pr.description = '#CHANGELOG\n## Fixes\nFoo, Bar, Baz\n#changelog\n## Features\nFizz, Bang'
+        changelog = utils.getChangelogForPr(pr)
+      })
+
+      it('uses default message with error message', () => {
+        expect(changelog).to.be.eql('No CHANGELOG section found in Pull Request description.\n' +
+          'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`\n' +
+          'Multiple changelog sections found. Line 1 and line 4.')
+      })
+    })
+
     describe('when changelog section is present', () => {
       beforeEach(() => {
-        pr.description = '# CHANGELOG\n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
+        pr.description = '#changelog\r\n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
+        changelog = utils.getChangelogForPr(pr)
+      })
+
+      it('grabs the changelog text', () => {
+        expect(changelog).to.be.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+      })
+    })
+
+    describe('when changelog section has extra space at the end', () => {
+      beforeEach(() => {
+        pr.description = '# CHANGELOG    \n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
         changelog = utils.getChangelogForPr(pr)
       })
 


### PR DESCRIPTION
This #fix# addresses the issue that carriage returns are present in the
API response from github inside the PR body.

# CHANGELOG
 * Fixes issue where `\r` characters in the pr description weren't properly handled. Who knew GitHub was built on Windows? ;) 
 * Fixes issue where users had to be extremely specific with their `# CHANGELOG` section heading. The following are now all valid as well: `#CHANGELOG`, `# CHANGELOG  `, `#changelog `, `# changelog`