### PR TITLE
Add newline after prepended info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.4.1
  * Fixes issue where `\r` characters in the pr description weren't properly handled. Who knew GitHub was built on Windows? ;) 
- * Fixes issue where users had to be extremely specific with their `# CHANGELOG` section heading. The following are now all valid as well: `#CHANGELOG`, `# CHANGELOG  `, `#changelog `, `# changelog`# 0.4.0
+ * Fixes issue where users had to be extremely specific with their `# CHANGELOG` section heading. The following are now all valid as well: `#CHANGELOG`, `# CHANGELOG  `, `#changelog `, `# changelog`
+
+# 0.4.0
 Added ability to maintain a `CHANGELOG.md` file automatically via Pull Requests. Whenever `pr-bumper` runs on a merge build, it now not only bumps `package.json`, but also prepends some content into `CHANGELOG.md` at the root of the repository. If that file doesn't exist, it's created.
 
 ## What is added to `CHANGELOG.md`?

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,6 @@ function getChangelogSectionIndex (lines) {
   let index = -1
   for (let i = 0; i < lines.length; i++) {
     const processedLine = lines[i].trim().toLowerCase()
-    console.log(`processedLine: [${processedLine}]`)
     if (validSectionHeaders.indexOf(processedLine) !== -1) {
       if (index !== -1) {
         throw new Error(`Multiple changelog sections found. Line ${index + 1} and line ${i + 1}.`)
@@ -253,7 +252,7 @@ const utils = {
    * @returns {Promise} - a promise resolved when changelog has been prepended
    */
   prependChangelog (info, changelogFile) {
-    const data = `# ${info.version}\n${info.changelog}`
+    const data = `# ${info.version}\n${info.changelog}\n\n`
     return prepend(changelogFile, data)
   },
 


### PR DESCRIPTION
This #fix# adds some newlines after the prepended changelog info so that that it formats properly.

# CHANGELOG
Format the `CHANGELOG.md` file properly by adding some newlines after the prepended entry.