### PR TITLE
gfm checkbox support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### This project uses [semver](semver.org), please check the scope of this pr:
+ - [ ] #patch# - backwards-compatible bug fix
+ - [ ] #minor# - adding functionality in a backwards-compatible manner
+ - [ ] #major# - incompatible API change
+
+# CHANGELOG
+Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ We also support the aliases of `BREAKING`, `FEATURE`, and `FIX`.
 | 1.2.3            | `#MAJOR#`    | 2.0.0          |
 | 1.2.3            | `#BREAKING#` | 2.0.0          |
 
+### GFM Checklist support
+You may also specify a list of possible scopes in a [GFM checklist](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
+ Example:
+ 
+ ### Check the scope of this pr:
+ - [ ] #patch# - bugfix, dependency update
+ - [ ] #minor# - new feature, backwards compatible
+ - [x] #major# - major feature, probably breaking API
+ - [ ] #breaking# - any change that breaks the API
+ 
+Combined with [Pull Request Templates](https://github.com/blog/2111-issue-and-pull-request-templates), contributors who are unfamiliar with pr-bumper will know exactly what to do before the build fails
 
 ## Integrations
 `pr-bumper` currently only supports pull requets on [GitHub](github.com),

--- a/README.md
+++ b/README.md
@@ -18,81 +18,88 @@ Use text from a pull request description to automatically bump the version numbe
 `pr-bumper` uses [Semantic Versioning](http://semver.org/).
 
 Pull requests must include a directive indicating the
-scope of the change being made (`MAJOR`/`MINOR`/`PATCH`). Directives are **case insensitive** and wrapped in `#` to
+scope of the change being made (`major`/`minor`/`patch`). Directives are **case insensitive** and wrapped in `#` to
 avoid a description such as
 
 ```
 Fixing a major bug in the code
 ```
 
-being considered a `MAJOR` change.
+being considered a `major` change.
 
-We also support the aliases of `BREAKING`, `FEATURE`, and `FIX`.
+We also support the aliases of `breaking`, `feature`, and `fix`.
 
 | Starting Version | Directive    | Ending Version |
 | :--------------: | :----------- | :------------: |
-| 1.2.3            | `#PATCH#`    | 1.2.4          |
-| 1.2.3            | `#FIX#`      | 1.2.4          |
-| 1.2.3            | `#MINOR#`    | 1.3.0          |
-| 1.2.3            | `#FEATURE#`  | 1.3.0          |
-| 1.2.3            | `#MAJOR#`    | 2.0.0          |
-| 1.2.3            | `#BREAKING#` | 2.0.0          |
+| 1.2.3            | `#patch#`    | 1.2.4          |
+| 1.2.3            | `#fix#`      | 1.2.4          |
+| 1.2.3            | `#minor#`    | 1.3.0          |
+| 1.2.3            | `#feature#`  | 1.3.0          |
+| 1.2.3            | `#major#`    | 2.0.0          |
+| 1.2.3            | `#breaking#` | 2.0.0          |
+
+
+[gfm-checklist-url]: https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
+[pr-template-url]: https://github.com/blog/2111-issue-and-pull-request-templates
 
 ### GFM Checklist support
-You may also specify a list of possible scopes in a [GFM checklist](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
+You may also specify a list of possible scopes in a [GFM checklist][gfm-checklist-url]
  Example:
- 
- ### Check the scope of this pr:
- - [ ] #patch# - bugfix, dependency update
- - [ ] #minor# - new feature, backwards compatible
- - [x] #major# - major feature, probably breaking API
- - [ ] #breaking# - any change that breaks the API
- 
-Combined with [Pull Request Templates](https://github.com/blog/2111-issue-and-pull-request-templates), contributors who are unfamiliar with pr-bumper will know exactly what to do before the build fails
 
+ ### This project uses [semver](semver.org), please check the scope of this pr:
+ - [ ] #patch# - backwards-compatible bug fix
+ - [ ] #minor# - adding functionality in a backwards-compatible manner
+ - [x] #major# - incompatible API change
+
+Combined with [Pull Request Templates][pr-template-url], contributors who are unfamiliar with `pr-bumper`
+will know exactly what to do before the build fails.
+
+[github-url]: https://github.com
+[bitbucket-url]: https://bitbucket.org/product/server
+[travis-url]: https://travis-ci.org
+[teamcity-url]: https://www.jetbrains.com/teamcity/
 ## Integrations
-`pr-bumper` currently only supports pull requets on [GitHub](github.com),
-but support is also planned for [Bitbucket Server](https://bitbucket.org/product/server).
+`pr-bumper` currently supports pull requests on [GitHub][github-url], and [Bitbucket Server][bitbucket-url]
 
-It is also optimized to work with [Travis CI](https://travis-ci.org) out-of-the box, but support is also
-planned for [TeamCity](https://www.jetbrains.com/teamcity/)
+It is also optimized to work with [Travis CI][travis-url] out-of-the box, but can be configured to work with
+[TeamCity][teamcity-url] as well using the [`.pr-bumper.json`](#pr-bumperjson) config file.
 
 ## Installation
 
-```
-npm install pr-bumper
-```
+  ```
+  npm install pr-bumper
+  ```
 
 ## Usage
 You can check for the existence of a valid directive in the current (open) pr (during the pr build) by using
 
-```
-pr-bumper check
-```
+  ```
+  pr-bumper check
+  ```
 
 You can perform the automated bump in the merge build by using:
 
-```
-pr-bumper bump
-```
+  ```
+  pr-bumper bump
+  ```
 
 ## Travis CI
 `pr-bumper` is optimized to work with Travis CI and by defaults uses Travis CI environment variables for configuration.
 
 Add the following snippets to your `.travis.yml` file to integrate `pr-bumper`
 
-```yaml
-branches:
-  except:
-    - /^v[0-9\.]+/
+  ```yaml
+  branches:
+    except:
+      - /^v[0-9\.]+/
 
-before_install:
-  - npm install -g pr-bumper
-  - pr-bumper check
+  before_install:
+    - npm install -g pr-bumper
+    - pr-bumper check
 
-before_deploy:
-  - pr-bumper bump
-```
+  before_deploy:
+    - pr-bumper bump
+  ```
 
 This will allow `pr-bumper` to be installed for your build, allow it to check for the existence of version-bump
 comments on your PRs, as well as allow it to automatically version-bump and git tag your releases before you deploy
@@ -111,25 +118,26 @@ You can do so by using the [Travis Client](https://github.com/travis-ci/travis.r
 
 First, you'll need to authenticate with `travis` (you can use the same token for that)
 
-```
-travis login --github-token your-token-goes-here
-travis encrypt GITHUB_TOKEN=your-token-goes-here --add -r owner/repo
-```
+  ```
+  travis login --github-token your-token-goes-here
+  travis encrypt GITHUB_TOKEN=your-token-goes-here --add -r owner/repo
+  ```
 
 If you do not use a fork workflow and your `origin` is the main repository, you can skip the `-r owner/repo` part.
 Otherwise, replace the `owner/repo` with the organization and repo of your `upstream` repository.
 
 [env-docs]: https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
-Also, to avoid rate-limit issues on API requests to github, you should also specify a `RO_GH_TOKEN` 
-for `pr-bumper` to use when making read requests to github. This is necessary because secure environment variables are not available
-to pull request builds when coming from forks in travis for [security reasons][env-docs].
+Also, to avoid rate-limit issues on API requests to github, you should also specify a `RO_GH_TOKEN`
+for `pr-bumper` to use when making read requests to github. This is necessary because secure environment variables are
+not available to pull request builds when coming from forks in travis for [security reasons][env-docs].
 
-> **NOTE** Since `RO_GH_TOKEN` is not secure, it is printed directly into your Travis Logs!!! 
+> **NOTE** Since `RO_GH_TOKEN` is not secure, it is printed directly into your Travis Logs!!!
 > So, make sure it has only read access to your repository. Hence the name `RO_GH_TOKEN` (Read Only GitHub Token)
 
 ## .pr-bumper.json
-If using TravisCI most configuration options will not be needed, but if you have a different CI or specific requirements 
-like handling changelog generation separately, configuration can be defined by placing a `.pr-bumper.json` file in the root of your repository.
+If using Travis CI most configuration options will not be needed, but if you have a different CI or specific
+requirements like handling changelog generation separately, configuration can be defined by placing a
+`.pr-bumper.json` file in the root of your repository.
 
 ### Bitbucket Server / TeamCity
 You can now configure `pr-bumper` to work with something other than Travis CI and GitHub.
@@ -167,25 +175,25 @@ Example TeamCity and Bitbucket setup:
 A string that provides the environment variable that holds the TeamCity build number on the agent that runs your build.
 One way to set that variable is with the following in your Build Step:
 
-```
-export TEAMCITY_BUILD_NUMBER="%teamcity.build.id%"
-```
+  ```
+  export TEAMCITY_BUILD_NUMBER="%teamcity.build.id%"
+  ```
 
 ### `ci.env.pr`
 A string that provides the environment variable that holds the PR number of the pull request
 being built (empty when a not a PR build).
 One way to fill that variable is by including the following in your Build Step:
 
-```
-stripped_branch=\$(echo "%teamcity.build.branch%" | sed -e "s/\/merge//")
-re='^[0-9]+$'
-if [[ \$stripped_branch =~ \$re ]]
-then
-    export TEAMCITY_PULL_REQUEST="\$stripped_branch"
-else
-    export TEAMCITY_PULL_REQUEST="false"
-fi
-```
+  ```
+  stripped_branch=\$(echo "%teamcity.build.branch%" | sed -e "s/\/merge//")
+  re='^[0-9]+$'
+  if [[ \$stripped_branch =~ \$re ]]
+  then
+      export TEAMCITY_PULL_REQUEST="\$stripped_branch"
+  else
+      export TEAMCITY_PULL_REQUEST="false"
+  fi
+  ```
 
 ### `ci.gitUser`
 You can configure the `email` and `name` that will be used by the `git` user for the `commit` that bumps the
@@ -219,8 +227,9 @@ Boolean whether to read the PR description to insert into CHANGELOG.md on bump. 
 Disable `prependChangelog` example:
 
 `.pr-bumper.json`
-```json
-{
-  "prependChangelog": false
-}
-```
+  ```json
+  {
+    "prependChangelog": false
+  }
+  ```
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,12 +156,28 @@ const utils = {
       throw new Error(`No version-bump scope found for PR #${pr.number} (${pr.url})`)
     }
 
+    let scope
+
     if (matches.length > 1) {
-      throw new Error(`Too many version-bump scopes found for PR #${pr.number} (${pr.url})`)
+      // check for GFM checkboxes
+      const gfmCheckbockRegex = /-\s\[x\].*?#(\w+)#/gi
+
+      let selectedScopes = []
+      let checkboxMatches
+      while ((checkboxMatches = gfmCheckbockRegex.exec(pr.description)) !== null) {
+        selectedScopes.push(checkboxMatches[1])
+      }
+
+      if (selectedScopes.length !== 1) {
+        throw new Error(`Too many version-bump scopes found for PR #${pr.number} (${pr.url})`)
+      }
+
+      scope = selectedScopes[0]
+    } else {
+      scope = matches[0].replace(/#/g, '')
     }
 
-    const scope = matches[0].replace(/#/g, '').toLowerCase()
-    return utils.getValidatedScope(scope, pr.number, pr.url)
+    return utils.getValidatedScope(scope.toLowerCase(), pr.number, pr.url)
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "bump"
   ],
   "author": "Adam Meadows [https://github.com/job13er]",
+  "contributors": [
+    "Matthew Dahl [https://github.com/sandersky]",
+    "Steven Glanzer [https://github.com/sglanzer]",
+    "Zak Henry [https://github.com/zakhenry]"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ciena-blueplanet/pr-bumper/issues"

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -368,7 +368,7 @@ describe('utils', () => {
       })
     })
 
-    describe('when GFM checkbox sytax is present with one scope checked', () => {
+    describe('when GFM checkbox syntax is present with one scope checked', () => {
       beforeEach(() => {
         pr.description = `
 ### Check the scope of this pr:
@@ -384,7 +384,7 @@ describe('utils', () => {
       })
     })
 
-    describe('when GFM checkbox sytax is present with multiple scopes checked', () => {
+    describe('when GFM checkbox syntax is present with multiple scopes checked', () => {
       beforeEach(() => {
         pr.description = `
 ### Check the scope of this pr:
@@ -400,6 +400,25 @@ describe('utils', () => {
         }
 
         expect(fn).to.throw('Too many version-bump scopes found for PR #12345 (my-pr-url)')
+      })
+    })
+
+    describe('when GFM checkbox syntax is present with one scope checked and other scopes mentioned', () => {
+      beforeEach(() => {
+        pr.description = `
+### Check the scope of this pr:
+- [ ] #patch# - bugfix, dependency update
+- [x] #minor# - new feature, backwards compatible
+- [ ] #major# - major feature, probably breaking API
+- [ ] #breaking# - any change that breaks the API
+
+Thought this might be #breaking# but on second thought it is a minor change
+`
+        scope = utils.getScopeForPr(pr)
+      })
+
+      it('calls .getValidatedScope() with proper arguments', () => {
+        expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
       })
     })
   })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -367,6 +367,41 @@ describe('utils', () => {
         expect(scope).to.be.equal('the-validated-scope')
       })
     })
+
+    describe('when GFM checkbox sytax is present with one scope checked', () => {
+      beforeEach(() => {
+        pr.description = `
+### Check the scope of this pr:
+- [ ] #patch# - bugfix, dependency update
+- [x] #minor# - new feature, backwards compatible
+- [ ] #major# - major feature, probably breaking API
+- [ ] #breaking# - any change that breaks the API`
+        scope = utils.getScopeForPr(pr)
+      })
+
+      it('calls .getValidatedScope() with proper arguments', () => {
+        expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
+      })
+    })
+
+    describe('when GFM checkbox sytax is present with multiple scopes checked', () => {
+      beforeEach(() => {
+        pr.description = `
+### Check the scope of this pr:
+- [x] #patch# - bugfix, dependency update
+- [ ] #minor# - new feature, backwards compatible
+- [x] #major# - major feature, probably breaking API
+- [ ] #breaking# - any change that breaks the API`
+      })
+
+      it('throws an error', () => {
+        const fn = () => {
+          utils.getScopeForPr(pr)
+        }
+
+        expect(fn).to.throw('Too many version-bump scopes found for PR #12345 (my-pr-url)')
+      })
+    })
   })
 
   describe('.getChangelogForPr()', () => {


### PR DESCRIPTION
This PR just cleans up the `README.md` a bit from #47 and adds a `PULL_REQUEST_TEMPLATE.md` to this repository. 

This is a new #feature# added by @zakhenry 

# CHANGELOG
 * **Added** support for using GFM Checkboxes to choose scope
 * **Added** a `PULL_REQUEST_TEMPLATE` for the `pr-bumper` repository itself