### PR TITLE
Restore default behavior for master branch

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ function processEnv (config) {
   config.ci.buildNumber = process.env[config.ci.env.buildNumber]
   config.prNumber = process.env[config.ci.env.pr]
   config.isPr = config.prNumber !== 'false'
-  config.branch = process.env[config.ci.env.branch]
+  config.branch = process.env[config.ci.env.branch] || 'master'
 
   logger.log(`pr-bumper::config: prNumber [${config.prNumber}], isPr [${config.isPr}]`)
 

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -295,6 +295,21 @@ describe('utils', () => {
           expect(config.prNumber).to.be.equal('false')
         })
       })
+
+      describe('when no branch env is given', () => {
+        beforeEach(() => {
+          delete _config.ci.env.branch
+
+          saveEnv(Object.keys(env), realEnv)
+          setEnv(env)
+
+          config = utils.getConfig(_config)
+        })
+
+        it('should default to master branch', () => {
+          expect(config.branch).to.be.equal('master')
+        })
+      })
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
 * **Restored** default behavior of using `master` branch if no `ci.env.branch` config is specified.
