### PR TITLE
Try codecov.io instead of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ node_js:
 branches:
   except:
   - /^v[0-9\.]+/
-before_install:
-- npm install -g codecov
 before_script:
 - VERBOSE=1 ./bin/cli.js check
 after_success:
-- codecov
+- bash <(curl -s https://codecov.io/bash) -f coverage/coverage.json
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ node_js:
 branches:
   except:
   - /^v[0-9\.]+/
-before_install:
-- npm install -g coveralls
 before_script:
 - VERBOSE=1 ./bin/cli.js check
 after_success:
-- cat coverage/lcov.info | coveralls
+- bash <(curl -s https://codecov.io/bash)
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ node_js:
 branches:
   except:
   - /^v[0-9\.]+/
+before_install:
+- npm install -g codecov
 before_script:
 - VERBOSE=1 ./bin/cli.js check
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- codecov
 addons:
   apt:
     sources:


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Attempted** to switch from [coveralls.io](http://coveralls.io) to [codecov.io](http://codecov.io)
