### PR TITLE
Make check fail on empty/missing #CHANGELOG

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": ["frost-standard"]
+  "extends": ["frost-standard"],
+  "plugins": ["mocha"],
+  "rules": {
+    "mocha/no-mocha-arrows": 2,
+    "mocha/valid-test-description": 2
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '5.3'
+- '6.9.1'
 branches:
   except:
   - /^v[0-9\.]+/

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -208,12 +208,13 @@ class Bumper {
   _getMergedPrInfo () {
     return this._getLastPr()
       .then((pr) => {
-        return Promise.all([utils.getChangelogForPr(pr), utils.getScopeForPr(pr)]).then((result) => {
-          return {
-            changelog: result[0],
-            scope: result[1]
-          }
-        })
+        return Promise.all([utils.getChangelogForPr(pr), utils.getScopeForPr(pr)])
+          .then(([changelog, scope]) => {
+            return {
+              changelog,
+              scope
+            }
+          })
       })
   }
 
@@ -228,10 +229,10 @@ class Bumper {
         return Promise.all([
           this.config.prependChangelog ? utils.getChangelogForPr(pr) : Promise.resolve(''),
           utils.getScopeForPr(pr)
-        ]).then((result) => {
+        ]).then(([changelog, scope]) => {
           return {
-            changelog: result[0],
-            scope: result[1]
+            changelog,
+            scope
           }
         })
       })

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -25,9 +25,7 @@ const utils = require('./utils')
  * @class
  */
 class Bumper {
-  // ====================================================================================
-  // Public Methods
-  // ====================================================================================
+  // = Public Methods ===================================================================
 
   /**
    * @param {Object} params - params obj
@@ -77,21 +75,6 @@ class Bumper {
   }
 
   /**
-   * process a dependency report
-   * @param {Object} config the .pr-bumper.json config
-   * @returns {Promise} a Promise
-   **/
-  _dependencies () {
-    const cwd = process.cwd()
-    let outputPath = __.get(this.config, 'dependencies.output.directory')
-    const absOutputPath = outputPath ? path.join(cwd, outputPath) : null
-    if (absOutputPath) {
-      return dependencies.run(cwd, absOutputPath, this.config)
-    }
-    return Promise.resolve('skipping dependencies')
-  }
-
-  /**
    * Check a PR for a version-bump comment
    * @returns {Promise} a promise resolved when complete or rejected on error
    */
@@ -101,15 +84,13 @@ class Bumper {
       return Promise.resolve()
     }
 
-    return this._getOpenPrScope()
-      .then((scope) => {
-        logger.log(`Found a ${scope} bump for the current PR`)
+    return this._getOpenPrInfo()
+      .then((info) => {
+        logger.log(`Found a ${info.scope} bump for the current PR`)
       })
   }
 
-  // ====================================================================================
-  // Private Methods
-  // ====================================================================================
+  // = Private Methods ==================================================================
 
   /**
    * Bump the version in package.json with the given scope
@@ -180,6 +161,21 @@ class Bumper {
   }
 
   /**
+   * process a dependency report
+   * @param {Object} config the .pr-bumper.json config
+   * @returns {Promise} a Promise
+   **/
+  _dependencies () {
+    const cwd = process.cwd()
+    let outputPath = __.get(this.config, 'dependencies.output.directory')
+    const absOutputPath = outputPath ? path.join(cwd, outputPath) : null
+    if (absOutputPath) {
+      return dependencies.run(cwd, absOutputPath, this.config)
+    }
+    return Promise.resolve('skipping dependencies')
+  }
+
+  /**
    * Grab the most recent PR
    * @returns {PrPromise} a promise resolved with the most recent PR
    */
@@ -207,27 +203,37 @@ class Bumper {
 
   /**
    * Get the PR scope for the current (merged) pull request
-   * @returns {Promise} a promise - resolved with a String scope of the PR or rejected if no valid scope found
+   * @returns {Promise} a promise - resolved with PR info (changelog and scope) or rejected on error
    */
   _getMergedPrInfo () {
     return this._getLastPr()
       .then((pr) => {
-        return {
-          changelog: utils.getChangelogForPr(pr),
-          scope: utils.getScopeForPr(pr)
-        }
+        return Promise.all([utils.getChangelogForPr(pr), utils.getScopeForPr(pr)]).then((result) => {
+          return {
+            changelog: result[0],
+            scope: result[1]
+          }
+        })
       })
   }
 
   /**
    * Get the pr scope for the current (open) pull request
-   * @returns {Promise} a promise - resolved with a String scope of the PR or rejected if no valid scope found
+   * @returns {Promise} a promise - resolved with PR info (changelog and scope) or rejected on error
    */
-  _getOpenPrScope () {
+  _getOpenPrInfo () {
     const vcs = this.vcs
     return vcs.getPr(this.config.prNumber)
       .then((pr) => {
-        return utils.getScopeForPr(pr)
+        return Promise.all([
+          this.config.prependChangelog ? utils.getChangelogForPr(pr) : Promise.resolve(''),
+          utils.getScopeForPr(pr)
+        ]).then((result) => {
+          return {
+            changelog: result[0],
+            scope: result[1]
+          }
+        })
       })
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -148,22 +148,22 @@ const utils = {
    * @throws Error if scope is invalid
    */
   getValidatedScope (scope, prNumber, prUrl) {
-    switch (scope) {
-      case 'fix': // fallthrough
-      case 'patch':
-        return 'patch'
-
-      case 'feature':  // fallthrough
-      case 'minor':
-        return 'minor'
-
-      case 'breaking': // fallthrough
-      case 'major':
-        return 'major'
-
-      default:
-        throw new Error(`Invalid version-bump scope [${scope}] found for PR #${prNumber} (${prUrl})`)
+    const scopeLookup = {
+      fix: 'patch',
+      patch: 'patch',
+      feature: 'minor',
+      minor: 'minor',
+      breaking: 'major',
+      major: 'major'
     }
+
+    const validatedScope = scopeLookup[scope]
+
+    if (!validatedScope) {
+      throw new Error(`Invalid version-bump scope [${scope}] found for PR #${prNumber} (${prUrl})`)
+    }
+
+    return validatedScope
   },
 
   /**
@@ -209,22 +209,18 @@ const utils = {
    * @returns {String} the changelog of the PR (from the pr description, if one exists, else '')
    */
   getChangelogForPr (pr) {
-    const defaultMsg = 'No CHANGELOG section found in Pull Request description.\n' +
-      'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`'
-
     const lines = pr.description.split('\n')
-    let index = -1
+    const index = getChangelogSectionIndex(lines)
     let changelog = ''
-    try {
-      index = getChangelogSectionIndex(lines)
-    } catch (e) {
-      return `${defaultMsg}\n${e.message}`
+
+    if (index >= 0) {
+      changelog = lines.slice(index + 1).join('\n')
     }
 
-    if (index < 0) {
-      changelog = defaultMsg
-    } else {
-      changelog = lines.slice(index + 1).join('\n')
+    if (changelog.trim() === '') {
+      const msg = 'No CHANGELOG content found in PR description.\n' +
+        'Please add a "# CHANGELOG" section to your PR description with some content describing your change'
+      throw new Error(msg)
     }
 
     return changelog

--- a/package.json
+++ b/package.json
@@ -47,11 +47,12 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^2.9.0",
-    "eslint-config-frost-standard": "^2.0.0",
+    "eslint": "^3.5.0",
+    "eslint-config-frost-standard": "^5.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "rewire": "^2.5.1",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git@github.com:ciena-blueplanet/pr-bumper.git"
   },
   "engines": {
-    "node": ">= 5.0"
+    "node": ">= 6.0"
   },
   "keywords": [
     "github",

--- a/tests/ci/base-spec.js
+++ b/tests/ci/base-spec.js
@@ -1,14 +1,18 @@
 'use strict'
 
+const chai = require('chai')
 const rewire = require('rewire')
 const sinon = require('sinon')
-const expect = require('chai').expect
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
+
 const logger = require('../../lib/logger')
 const CiBase = rewire('../../lib/ci/base')
 
-describe('CiBase', () => {
+describe('CiBase', function () {
   let execStub, revertExecRewire, base, sandbox
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create()
 
     // get rid of all logging messages in the tests (and let us test for them if we want)
@@ -21,7 +25,7 @@ describe('CiBase', () => {
     base = new CiBase({id: 'config', branch: 'my-branch'}, {id: 'vcs'})
   })
 
-  afterEach(() => {
+  afterEach(function () {
     // undo the rewiring
     revertExecRewire()
 
@@ -29,75 +33,75 @@ describe('CiBase', () => {
     sandbox.restore()
   })
 
-  it('saves the config', () => {
+  it('should save the config', function () {
     expect(base.config).to.be.eql({id: 'config', branch: 'my-branch'})
   })
 
-  it('saves the vcs', () => {
+  it('should save the vcs', function () {
     expect(base.vcs).to.be.eql({id: 'vcs'})
   })
 
-  describe('.add()', () => {
+  describe('.add()', function () {
     let result
-    beforeEach(() => {
+    beforeEach(function () {
       execStub.returns(Promise.resolve('added'))
       return base.add(['foo', 'bar', 'baz']).then((res) => {
         result = res
       })
     })
 
-    it('adds the files to git', () => {
-      expect(execStub.lastCall.args).to.be.eql(['git add foo bar baz'])
+    it('should add the files to git', function () {
+      expect(execStub).to.have.been.calledWith('git add foo bar baz')
     })
 
-    it('resolves with the result of the git command', () => {
+    it('should resolve with the result of the git command', function () {
       expect(result).to.be.equal('added')
     })
   })
 
-  describe('.commit()', () => {
+  describe('.commit()', function () {
     let result
-    beforeEach(() => {
+    beforeEach(function () {
       execStub.returns(Promise.resolve('committed'))
       return base.commit('my summary message', 'my detail message').then((res) => {
         result = res
       })
     })
 
-    it('commits the files to git', () => {
-      expect(execStub.lastCall.args).to.be.eql(['git commit -m "my summary message" -m "my detail message"'])
+    it('should commit the files to git', function () {
+      expect(execStub).to.have.been.calledWith('git commit -m "my summary message" -m "my detail message"')
     })
 
-    it('resolves with the result of the git command', () => {
+    it('should resolve with the result of the git command', function () {
       expect(result).to.be.equal('committed')
     })
   })
 
-  describe('.push()', () => {
+  describe('.push()', function () {
     let result
-    beforeEach(() => {
+    beforeEach(function () {
       execStub.returns(Promise.resolve('pushed'))
       return base.push().then((res) => {
         result = res
       })
     })
 
-    it('logs that it is about to push', () => {
-      expect(logger.log.lastCall.args).to.be.eql(['Pushing my-branch to origin'])
+    it('should log that it is about to push', function () {
+      expect(logger.log).to.have.been.calledWith('Pushing my-branch to origin')
     })
 
-    it('pushes origin to master with --tags', () => {
-      expect(execStub.lastCall.args).to.be.eql(['git push origin my-branch --tags'])
+    it('should push origin to master with --tags', function () {
+      expect(execStub).to.have.been.calledWith('git push origin my-branch --tags')
     })
 
-    it('resolves with the result of the git command', () => {
+    it('should resolve with the result of the git command', function () {
       expect(result).to.be.equal('pushed')
     })
   })
 
-  describe('.setupGitEnv()', () => {
+  describe('.setupGitEnv()', function () {
     let result
-    beforeEach(() => {
+    beforeEach(function () {
       base.config = {
         ci: {
           gitUser: {
@@ -113,15 +117,15 @@ describe('CiBase', () => {
       })
     })
 
-    it('configures the git user\'s email address', () => {
-      expect(execStub.firstCall.args).to.be.eql(['git config --global user.email "ci-user@domain.com"'])
+    it('should configure the git user\'s email address', function () {
+      expect(execStub).to.have.been.calledWith('git config --global user.email "ci-user@domain.com"')
     })
 
-    it('configures the git user\'s name', () => {
-      expect(execStub.secondCall.args).to.be.eql(['git config --global user.name "ci-user"'])
+    it('should configure the git user\'s name', function () {
+      expect(execStub).to.have.been.calledWith('git config --global user.name "ci-user"')
     })
 
-    it('resolves with the result of the git command', () => {
+    it('should resolve with the result of the git command', function () {
       expect(result).to.be.equal('executed')
     })
   })

--- a/tests/ci/teamcity-spec.js
+++ b/tests/ci/teamcity-spec.js
@@ -1,18 +1,22 @@
 'use strict'
 
+const chai = require('chai')
 const sinon = require('sinon')
-const expect = require('chai').expect
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
+
 const logger = require('../../lib/logger')
 const CiBase = require('../../lib/ci/base')
 const TeamCity = require('../../lib/ci/teamcity')
 const testUtils = require('./utils')
 const ensureCiBaseMethodIsUsed = testUtils.ensureCiBaseMethodIsUsed
 
-describe('TeamCity', () => {
+describe('TeamCity', function () {
   let teamcity, sandbox
   let ctx = {}
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create()
 
     // get rid of all logging messages in the tests (and let us test for them if we want)
@@ -23,20 +27,19 @@ describe('TeamCity', () => {
     ctx.sandbox = sandbox
   })
 
-  afterEach(() => {
-    // remove all stubs/spies
+  afterEach(function () {
     sandbox.restore()
   })
 
-  it('saves the config', () => {
+  it('should save the config', function () {
     expect(teamcity.config).to.be.eql({id: 'config'})
   })
 
-  it('saves the vcs', () => {
+  it('should save the vcs', function () {
     expect(teamcity.vcs).to.be.eql({id: 'vcs'})
   })
 
-  it('should extend CiBase', () => {
+  it('should extend CiBase', function () {
     expect(teamcity).to.be.an.instanceof(CiBase)
   })
 

--- a/tests/ci/utils.js
+++ b/tests/ci/utils.js
@@ -1,13 +1,18 @@
 'use strict'
 
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
+
 const CiBase = require('../../lib/ci/base')
-const expect = require('chai').expect
 
 module.exports = {
   ensureCiBaseMethodIsUsed (ctx, methodName) {
-    describe(`.${methodName}()`, () => {
+    describe(`.${methodName}()`, function () {
       let ci, result
-      beforeEach(() => {
+
+      beforeEach(function () {
         ci = ctx.ci
         ctx.sandbox.stub(CiBase.prototype, methodName).returns(Promise.resolve(`${methodName}-finished`))
 
@@ -16,11 +21,11 @@ module.exports = {
         })
       })
 
-      it(`calls the base ${methodName}()`, () => {
-        expect(CiBase.prototype[methodName].lastCall.args).to.be.eql(['some-args'])
+      it(`should call the base ${methodName}()`, function () {
+        expect(CiBase.prototype[methodName]).to.have.been.calledWith('some-args')
       })
 
-      it(`resolves with the result of the base ${methodName}()`, () => {
+      it(`should resolve with the result of the base ${methodName}()`, function () {
         expect(result).to.be.equal(`${methodName}-finished`)
       })
     })

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -1,8 +1,11 @@
 'use strict'
 
-const expect = require('chai').expect
+const chai = require('chai')
 const Promise = require('promise')
 const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
 
 const utils = require('../lib/utils')
 const logger = require('../lib/logger')
@@ -16,21 +19,21 @@ const GitHub = require('../lib/vcs/github')
 
 const Bumper = require('../lib/bumper')
 
-describe('Cli', () => {
+describe('Cli', function () {
   let cli, sandbox
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create()
     sandbox.stub(logger, 'log')
 
     cli = new Cli()
   })
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore()
   })
 
-  describe('_getBumper', () => {
-    it('returns an instance of bumper given params', () => {
+  describe('_getBumper', function () {
+    it('should return an instance of bumper given params', function () {
       const bumper = cli._getBumper({
         ci: {id: 'ci'},
         vcs: {id: 'vcs'},
@@ -41,9 +44,9 @@ describe('Cli', () => {
     })
   })
 
-  describe('.run()', () => {
+  describe('.run()', function () {
     let bumper, result, error
-    beforeEach(() => {
+    beforeEach(function () {
       bumper = {
         bump: sandbox.stub().returns(Promise.resolve('bumped')),
         check: sandbox.stub().returns(Promise.resolve('checked'))
@@ -55,8 +58,8 @@ describe('Cli', () => {
       sandbox.stub(cli, '_getBumper').returns(bumper)
     })
 
-    describe('bump', () => {
-      beforeEach(() => {
+    describe('bump', function () {
+      beforeEach(function () {
         result = ''
         error = ''
 
@@ -70,37 +73,37 @@ describe('Cli', () => {
           })
       })
 
-      it('gets the config', () => {
-        expect(utils.getConfig.calledOnce).to.be.ok
+      it('should get the config', function () {
+        expect(utils.getConfig).to.have.callCount(1)
       })
 
-      it('gets the vcs', () => {
-        expect(cli._getVcs.lastCall.args).to.be.eql([{id: 'config'}])
+      it('should gets the vcs', function () {
+        expect(cli._getVcs).to.have.been.calledWith({id: 'config'})
       })
 
-      it('gets the ci', () => {
-        expect(cli._getCi.lastCall.args).to.be.eql([{id: 'config'}, {id: 'vcs'}])
+      it('should get the ci', function () {
+        expect(cli._getCi).to.have.been.calledWith({id: 'config'}, {id: 'vcs'})
       })
 
-      it('gets the bumper', () => {
-        expect(cli._getBumper.lastCall.args).to.be.eql([{
+      it('should get the bumper', function () {
+        expect(cli._getBumper).to.have.been.calledWith({
           ci: {id: 'ci'},
           config: {id: 'config'},
           vcs: {id: 'vcs'}
-        }])
+        })
       })
 
-      it('resolves with the result of bump', () => {
+      it('should resolve with the result of bump', function () {
         expect(result).to.be.equal('bumped')
       })
 
-      it('does not error', () => {
-        expect(error).not.to.be.ok
+      it('should not error', function () {
+        expect(error).to.equal('')
       })
     })
 
-    describe('check', () => {
-      beforeEach(() => {
+    describe('check', function () {
+      beforeEach(function () {
         result = ''
         error = ''
 
@@ -114,37 +117,37 @@ describe('Cli', () => {
           })
       })
 
-      it('gets the config', () => {
-        expect(utils.getConfig.calledOnce).to.be.ok
+      it('should get the config', function () {
+        expect(utils.getConfig).to.have.callCount(1)
       })
 
-      it('gets the vcs', () => {
-        expect(cli._getVcs.lastCall.args).to.be.eql([{id: 'config'}])
+      it('should get the vcs', function () {
+        expect(cli._getVcs).to.have.been.calledWith({id: 'config'})
       })
 
-      it('gets the ci', () => {
-        expect(cli._getCi.lastCall.args).to.be.eql([{id: 'config'}, {id: 'vcs'}])
+      it('should get the ci', function () {
+        expect(cli._getCi).to.have.been.calledWith({id: 'config'}, {id: 'vcs'})
       })
 
-      it('gets the bumper', () => {
-        expect(cli._getBumper.lastCall.args).to.be.eql([{
+      it('should get the bumper', function () {
+        expect(cli._getBumper).to.have.been.calledWith({
           ci: {id: 'ci'},
           config: {id: 'config'},
           vcs: {id: 'vcs'}
-        }])
+        })
       })
 
-      it('resolves with the result of check', () => {
+      it('should resolve with the result of check', function () {
         expect(result).to.be.equal('checked')
       })
 
-      it('does not error', () => {
-        expect(error).not.to.be.ok
+      it('should not error', function () {
+        expect(error).to.equal('')
       })
     })
 
-    describe('invalid command', () => {
-      beforeEach(() => {
+    describe('invalid command', function () {
+      beforeEach(function () {
         result = ''
         error = ''
 
@@ -158,81 +161,79 @@ describe('Cli', () => {
           })
       })
 
-      it('rejects with an error', () => {
+      it('should reject with an error', function () {
         expect(error).to.be.equal('Invalid command: foo-bar')
       })
 
-      it('does not resolve', () => {
-        expect(result).not.to.be.ok
+      it('should not resolve', function () {
+        expect(result).to.equal('')
       })
     })
   })
 
-  describe('._getCi()', () => {
+  describe('._getCi()', function () {
     let config, vcs, ci
 
-    beforeEach(() => {
+    beforeEach(function () {
       config = {ci: {}}
       vcs = {id: 'vcs'}
     })
 
-    describe('with teamcity provider', () => {
-      beforeEach(() => {
+    describe('with teamcity provider', function () {
+      beforeEach(function () {
         config.ci.provider = 'teamcity'
         ci = cli._getCi(config, vcs)
       })
 
-      it('passess along config', () => {
+      it('should pass along config', function () {
         expect(ci.config).to.be.eql(config)
       })
 
-      it('passess along vcs', () => {
+      it('should pass along vcs', function () {
         expect(ci.vcs).to.be.eql(vcs)
       })
 
-      it('creates a TeamCity instance', () => {
+      it('should create a TeamCity instance', function () {
         expect(ci).to.be.an.instanceof(TeamCity)
       })
     })
 
-    describe('with travis provider', () => {
-      beforeEach(() => {
+    describe('with travis provider', function () {
+      beforeEach(function () {
         config.ci.provider = 'travis'
         ci = cli._getCi(config, vcs)
       })
 
-      it('passess along config', () => {
+      it('should pass along config', function () {
         expect(ci.config).to.be.eql(config)
       })
 
-      it('passess along vcs', () => {
+      it('should pass along vcs', function () {
         expect(ci.vcs).to.be.eql(vcs)
       })
 
-      it('creates a Travis instance', () => {
+      it('should create a Travis instance', function () {
         expect(ci).to.be.an.instanceof(Travis)
       })
     })
 
-    describe('with invalid provider', () => {
-      beforeEach(() => {
+    describe('with invalid provider', function () {
+      beforeEach(function () {
         config.ci.provider = 'unknown provider'
       })
 
-      it('throws an error', () => {
-        const fn = () => {
-          ci = cli._getCi(config, vcs)
-        }
-
-        expect(fn).to.throw('Invalid ci provider: [unknown provider]')
+      it('should throw an error', function () {
+        expect(() => {
+          cli._getCi(config, vcs)
+        }).to.throw('Invalid ci provider: [unknown provider]')
       })
     })
   })
 
-  describe('._getVcs()', () => {
+  describe('._getVcs()', function () {
     let config, vcs
 
-    beforeEach(() => {
+    beforeEach(function () {
       config = {
         vcs: {
           auth: {}
@@ -240,8 +241,8 @@ describe('Cli', () => {
       }
     })
 
-    describe('with bitbucket-server provider', () => {
-      beforeEach(() => {
+    describe('with bitbucket-server provider', function () {
+      beforeEach(function () {
         config.vcs.provider = 'bitbucket-server'
         config.vcs.auth = {
           username: 'foo',
@@ -250,42 +251,39 @@ describe('Cli', () => {
         vcs = cli._getVcs(config)
       })
 
-      it('passess along config', () => {
+      it('should pass along config', function () {
         expect(vcs.config).to.be.eql(config)
       })
 
-      it('creates a BitbucketServer instance', () => {
+      it('should create a BitbucketServer instance', function () {
         expect(vcs).to.be.an.instanceof(BitbucketServer)
       })
     })
 
-    describe('with github provider', () => {
-      beforeEach(() => {
+    describe('with github provider', function () {
+      beforeEach(function () {
         config.vcs.provider = 'github'
-        console.log('getting a github vcs')
         vcs = cli._getVcs(config)
       })
 
-      it('passess along config', () => {
+      it('should pass along config', function () {
         expect(vcs.config).to.be.eql(config)
       })
 
-      it('creates a GitHub instance', () => {
+      it('should create a GitHub instance', function () {
         expect(vcs).to.be.an.instanceof(GitHub)
       })
     })
 
-    describe('with invalid provider', () => {
-      beforeEach(() => {
+    describe('with invalid provider', function () {
+      beforeEach(function () {
         config.vcs.provider = 'unknown provider'
       })
 
-      it('throws an error', () => {
-        const fn = () => {
-          vcs = cli._getVcs(config)
-        }
-
-        expect(fn).to.throw('Invalid vcs provider: [unknown provider]')
+      it('should throw an error', function () {
+        expect(() => {
+          cli._getVcs(config)
+        }).to.throw('Invalid vcs provider: [unknown provider]')
       })
     })
   })

--- a/tests/logger-spec.js
+++ b/tests/logger-spec.js
@@ -1,26 +1,29 @@
 'use strict'
 
-const expect = require('chai').expect
+const chai = require('chai')
 const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
 
 const logger = require('../lib/logger')
 
-describe('logger', () => {
+describe('logger', function () {
   let stub
-  describe('.log()', () => {
-    it('logs to console', () => {
+  describe('.log()', function () {
+    it('should log to console', function () {
       stub = sinon.stub(console, 'log')
       logger.log('foo bar baz')
-      expect(console.log.lastCall.args).to.be.eql(['foo bar baz'])
+      expect(console.log).to.have.been.calledWith('foo bar baz')
       stub.restore()
     })
   })
 
-  describe('.error()', () => {
-    it('logs to console', () => {
+  describe('.error()', function () {
+    it('should log to console', function () {
       stub = sinon.stub(console, 'error')
       logger.error('foo bar baz')
-      expect(console.error.lastCall.args).to.be.eql(['foo bar baz'])
+      expect(console.error).to.have.been.calledWith('foo bar baz')
       stub.restore()
     })
   })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -33,44 +33,44 @@ function setEnv (env) {
  * @param {Object} ctx - the context object for the tests
  */
 function verifyGitHubTravisDefaults (ctx) {
-  describe('uses the right github/travis default', () => {
+  describe('when using github/travis defaults', function () {
     let config
-    beforeEach(() => {
+    beforeEach(function () {
       config = ctx.config
     })
 
-    it('git user', () => {
+    it('should use the proper git user', function () {
       expect(config.ci.gitUser).to.be.eql({
         email: 'travis.ci.ciena@gmail.com',
         name: 'Travis CI'
       })
     })
 
-    it('ci provider', () => {
+    it('should use the proper ci provider', function () {
       expect(config.ci.provider).to.be.equal('travis')
     })
 
-    it('owner', () => {
+    it('should have the proper owner', function () {
       expect(config.owner).to.be.equal('jdoe')
     })
 
-    it('branch', () => {
+    it('should have the proper branch', function () {
       expect(config.branch).to.be.equal('my-branch')
     })
 
-    it('repo', () => {
+    it('should have the proper repo', function () {
       expect(config.repo).to.be.equal('john-and-jane')
     })
 
-    it('vcs domain', () => {
+    it('should have the proper vcs domain', function () {
       expect(config.vcs.domain).to.be.equal('github.com')
     })
 
-    it('vcs provider', () => {
+    it('should have the proper vcs provider', function () {
       expect(config.vcs.provider).to.be.equal('github')
     })
 
-    it('vcs auth', () => {
+    it('should have the proper vcs auth', function () {
       expect(config.vcs.auth).to.be.eql({
         password: undefined,
         readToken: '12345',
@@ -86,44 +86,44 @@ function verifyGitHubTravisDefaults (ctx) {
  * @param {Object} ctx - the context object for the tests
  */
 function verifyBitbucketTeamcityOverrides (ctx) {
-  describe('uses the right bitbucket/teamcity overrides', () => {
+  describe('when using bitbucket/teamcity overrides', function () {
     let config
-    beforeEach(() => {
+    beforeEach(function () {
       config = ctx.config
     })
 
-    it('git user', () => {
+    it('should have the proper git user', function () {
       expect(config.ci.gitUser).to.be.eql({
         email: 'teamcity@domain.com',
         name: 'teamcity'
       })
     })
 
-    it('ci provider', () => {
+    it('should have the proper ci provider', function () {
       expect(config.ci.provider).to.be.equal('teamcity')
     })
 
-    it('owner', () => {
+    it('should have the proper owner', function () {
       expect(config.owner).to.be.equal('my-project')
     })
 
-    it('repo', () => {
+    it('should have the proper repo', function () {
       expect(config.repo).to.be.equal('my-repo')
     })
 
-    it('branch', () => {
+    it('should have the proper branch', function () {
       expect(config.branch).to.be.equal('my-branch')
     })
 
-    it('vcs domain', () => {
+    it('should have the proper vcs domain', function () {
       expect(config.vcs.domain).to.be.equal('bitbucket.domain.com')
     })
 
-    it('vcs provider', () => {
+    it('should have the proper vcs provider', function () {
       expect(config.vcs.provider).to.be.equal('bitbucket-server')
     })
 
-    it('vcs auth', () => {
+    it('should have the proper vcs auth', function () {
       expect(config.vcs.auth).to.be.eql({
         password: 'teamcity12345',
         readToken: undefined,
@@ -134,33 +134,33 @@ function verifyBitbucketTeamcityOverrides (ctx) {
   })
 }
 
-describe('utils', () => {
+describe('utils', function () {
   let sandbox
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create()
     sandbox.stub(logger, 'log')
   })
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore()
   })
 
-  describe('.getConfig()', () => {
+  describe('.getConfig()', function () {
     let config, env, realEnv
 
-    beforeEach(() => {
+    beforeEach(function () {
       realEnv = {}
     })
 
-    afterEach(() => {
+    afterEach(function () {
       // restore the realEnv
       setEnv(realEnv)
     })
 
-    describe('GitHub/Travis (default case)', () => {
+    describe('GitHub/Travis (default case)', function () {
       let ctx = {}
-      beforeEach(() => {
+      beforeEach(function () {
         env = {
           'TRAVIS_BRANCH': 'my-branch',
           'TRAVIS_BUILD_NUMBER': '123',
@@ -170,8 +170,8 @@ describe('utils', () => {
         }
       })
 
-      describe('when doing a pull request build', () => {
-        beforeEach(() => {
+      describe('when doing a pull request build', function () {
+        beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = '13'
 
           saveEnv(Object.keys(env), realEnv)
@@ -183,17 +183,17 @@ describe('utils', () => {
 
         verifyGitHubTravisDefaults(ctx)
 
-        it('sets isPr to true', () => {
-          expect(config.isPr).to.be.true
+        it('should set isPr to true', function () {
+          expect(config.isPr).to.equal(true)
         })
 
-        it('sets prNumber to the PR number', () => {
+        it('should set prNumber to the PR number', function () {
           expect(config.prNumber).to.be.equal('13')
         })
       })
 
-      describe('when doing a merge build', () => {
-        beforeEach(() => {
+      describe('when doing a merge build', function () {
+        beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = 'false'
 
           saveEnv(Object.keys(env), realEnv)
@@ -204,21 +204,21 @@ describe('utils', () => {
 
         verifyGitHubTravisDefaults(ctx)
 
-        it('sets isPr to false', () => {
-          expect(config.isPr).to.be.false
+        it('should set isPr to false', function () {
+          expect(config.isPr).to.equal(false)
         })
 
-        it('sets prNumber to false', () => {
+        it('should set prNumber to false', function () {
           expect(config.prNumber).to.be.equal('false')
         })
       })
     })
 
-    describe('Bitbucket/TeamCity', () => {
+    describe('Bitbucket/TeamCity', function () {
       let ctx = {}
       let _config
 
-      beforeEach(() => {
+      beforeEach(function () {
         env = {
           'TEAMCITY_BRANCH': 'my-branch',
           'TEAMCITY_BUILD_NUMBER': '123',
@@ -253,8 +253,8 @@ describe('utils', () => {
         }
       })
 
-      describe('when doing a pull request build', () => {
-        beforeEach(() => {
+      describe('when doing a pull request build', function () {
+        beforeEach(function () {
           env.TEAMCITY_PULL_REQUEST = '13'
 
           saveEnv(Object.keys(env), realEnv)
@@ -266,17 +266,17 @@ describe('utils', () => {
 
         verifyBitbucketTeamcityOverrides(ctx)
 
-        it('sets isPr to true', () => {
-          expect(config.isPr).to.be.true
+        it('should set isPr to true', function () {
+          expect(config.isPr).to.equal(true)
         })
 
-        it('sets prNumber to the PR number', () => {
+        it('should set prNumber to the PR number', function () {
           expect(config.prNumber).to.be.equal('13')
         })
       })
 
-      describe('when doing a merge build', () => {
-        beforeEach(() => {
+      describe('when doing a merge build', function () {
+        beforeEach(function () {
           env.TEAMCITY_PULL_REQUEST = 'false'
 
           saveEnv(Object.keys(env), realEnv)
@@ -287,17 +287,17 @@ describe('utils', () => {
 
         verifyBitbucketTeamcityOverrides(ctx)
 
-        it('sets isPr to false', () => {
-          expect(config.isPr).to.be.false
+        it('should set isPr to false', function () {
+          expect(config.isPr).to.equal(false)
         })
 
-        it('sets prNumber to false', () => {
+        it('should set prNumber to false', function () {
           expect(config.prNumber).to.be.equal('false')
         })
       })
 
-      describe('when no branch env is given', () => {
-        beforeEach(() => {
+      describe('when no branch env is given', function () {
+        beforeEach(function () {
           delete _config.ci.env.branch
 
           saveEnv(Object.keys(env), realEnv)
@@ -306,14 +306,14 @@ describe('utils', () => {
           config = utils.getConfig(_config)
         })
 
-        it('should default to master branch', () => {
+        it('should default to master branch', function () {
           expect(config.branch).to.be.equal('master')
         })
       })
     })
   })
 
-  describe('.getValidatedScope()', () => {
+  describe('.getValidatedScope()', function () {
     const prUrl = 'my-pr-url'
     const prNum = '12345'
     const scopes = {
@@ -326,12 +326,12 @@ describe('utils', () => {
     }
 
     __.forIn(scopes, (value, key) => {
-      it(`handles ${key}`, () => {
+      it(`handles ${key}`, function () {
         expect(utils.getValidatedScope(key, prNum, prUrl)).to.be.equal(value)
       })
     })
 
-    it('throws on invalid scope', () => {
+    it('should throw on invalid scope', function () {
       const fn = () => {
         utils.getValidatedScope('foo-bar', prNum, prUrl)
       }
@@ -340,9 +340,9 @@ describe('utils', () => {
     })
   })
 
-  describe('.getScopeForPr()', () => {
+  describe('.getScopeForPr()', function () {
     let pr, scope
-    beforeEach(() => {
+    beforeEach(function () {
       pr = {
         description: '',
         number: '12345',
@@ -351,12 +351,12 @@ describe('utils', () => {
       sandbox.stub(utils, 'getValidatedScope').returns('the-validated-scope')
     })
 
-    describe('when no version-bump present', () => {
-      beforeEach(() => {
+    describe('when no version-bump present', function () {
+      beforeEach(function () {
         pr.description = 'My super-cool new feature'
       })
 
-      it('throws an error', () => {
+      it('should throw an error', function () {
         const fn = () => {
           utils.getScopeForPr(pr)
         }
@@ -365,12 +365,12 @@ describe('utils', () => {
       })
     })
 
-    describe('when multiple version-bumps are present', () => {
-      beforeEach(() => {
+    describe('when multiple version-bumps are present', function () {
+      beforeEach(function () {
         pr.description = 'This is my cool #feature# or is it a #fix#?'
       })
 
-      it('throws an error', () => {
+      it('should throw an error', function () {
         const fn = () => {
           utils.getScopeForPr(pr)
         }
@@ -379,23 +379,23 @@ describe('utils', () => {
       })
     })
 
-    describe('when a single version-bump is present', () => {
-      beforeEach(() => {
+    describe('when a single version-bump is present', function () {
+      beforeEach(function () {
         pr.description = 'This is my super-cool #feature#'
         scope = utils.getScopeForPr(pr)
       })
 
-      it('calls .getValidatedScope() with proper arguments', () => {
+      it('should call .getValidatedScope() with proper arguments', function () {
         expect(utils.getValidatedScope.lastCall.args).to.be.eql(['feature', '12345', 'my-pr-url'])
       })
 
-      it('returns the result of .getValidatedScope()', () => {
+      it('should return the result of .getValidatedScope()', function () {
         expect(scope).to.be.equal('the-validated-scope')
       })
     })
 
-    describe('when GFM checkbox syntax is present with one scope checked', () => {
-      beforeEach(() => {
+    describe('when GFM checkbox syntax is present with one scope checked', function () {
+      beforeEach(function () {
         pr.description = `
 ### Check the scope of this pr:
 - [ ] #patch# - bugfix, dependency update
@@ -405,13 +405,13 @@ describe('utils', () => {
         scope = utils.getScopeForPr(pr)
       })
 
-      it('calls .getValidatedScope() with proper arguments', () => {
+      it('should call .getValidatedScope() with proper arguments', function () {
         expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
       })
     })
 
-    describe('when GFM checkbox syntax is present with multiple scopes checked', () => {
-      beforeEach(() => {
+    describe('when GFM checkbox syntax is present with multiple scopes checked', function () {
+      beforeEach(function () {
         pr.description = `
 ### Check the scope of this pr:
 - [x] #patch# - bugfix, dependency update
@@ -420,7 +420,7 @@ describe('utils', () => {
 - [ ] #breaking# - any change that breaks the API`
       })
 
-      it('throws an error', () => {
+      it('should throw an error', function () {
         const fn = () => {
           utils.getScopeForPr(pr)
         }
@@ -429,8 +429,8 @@ describe('utils', () => {
       })
     })
 
-    describe('when GFM checkbox syntax is present with one scope checked and other scopes mentioned', () => {
-      beforeEach(() => {
+    describe('when GFM checkbox syntax is present with one scope checked and other scopes mentioned', function () {
+      beforeEach(function () {
         pr.description = `
 ### Check the scope of this pr:
 - [ ] #patch# - bugfix, dependency update
@@ -443,15 +443,19 @@ Thought this might be #breaking# but on second thought it is a minor change
         scope = utils.getScopeForPr(pr)
       })
 
-      it('calls .getValidatedScope() with proper arguments', () => {
+      it('should call .getValidatedScope() with proper arguments', function () {
         expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
       })
     })
   })
 
-  describe('.getChangelogForPr()', () => {
+  describe('.getChangelogForPr()', function () {
+    const errorMsg = 'No CHANGELOG content found in PR description.\n' +
+      'Please add a "# CHANGELOG" section to your PR description with some content describing your change'
+
     let pr, changelog
-    beforeEach(() => {
+
+    beforeEach(function () {
       pr = {
         description: '',
         number: '12345',
@@ -459,49 +463,60 @@ Thought this might be #breaking# but on second thought it is a minor change
       }
     })
 
-    describe('when no changelog present', () => {
-      beforeEach(() => {
+    describe('when no changelog present', function () {
+      beforeEach(function () {
         pr.description = 'My super-cool new feature'
-        changelog = utils.getChangelogForPr(pr)
       })
 
-      it('uses default message', () => {
-        expect(changelog).to.be.eql('No CHANGELOG section found in Pull Request description.\n' +
-          'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`')
+      it('should throw an error', function () {
+        expect(() => {
+          utils.getChangelogForPr(pr)
+        }).to.throw(Error, errorMsg)
       })
     })
 
-    describe('when multiple changelog sections are present', () => {
-      beforeEach(() => {
+    describe('when changelog empty', function () {
+      beforeEach(function () {
+        pr.description = 'My super-cool new feature\n #CHANGELOG'
+      })
+
+      it('should throw an error', function () {
+        expect(() => {
+          utils.getChangelogForPr(pr)
+        }).to.throw(Error, errorMsg)
+      })
+    })
+
+    describe('when multiple changelog sections are present', function () {
+      beforeEach(function () {
         pr.description = '#CHANGELOG\n## Fixes\nFoo, Bar, Baz\n#changelog\n## Features\nFizz, Bang'
-        changelog = utils.getChangelogForPr(pr)
       })
 
-      it('uses default message with error message', () => {
-        expect(changelog).to.be.eql('No CHANGELOG section found in Pull Request description.\n' +
-          'Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`\n' +
-          'Multiple changelog sections found. Line 1 and line 4.')
+      it('should throw an error', function () {
+        expect(() => {
+          utils.getChangelogForPr(pr)
+        }).to.throw(Error, 'Multiple changelog sections found. Line 1 and line 4.')
       })
     })
 
-    describe('when changelog section is present', () => {
-      beforeEach(() => {
+    describe('when changelog section is present', function () {
+      beforeEach(function () {
         pr.description = '#changelog\r\n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
         changelog = utils.getChangelogForPr(pr)
       })
 
-      it('grabs the changelog text', () => {
+      it('should grab the changelog text', function () {
         expect(changelog).to.be.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
       })
     })
 
-    describe('when changelog section has extra space at the end', () => {
-      beforeEach(() => {
+    describe('when changelog section has extra space at the end', function () {
+      beforeEach(function () {
         pr.description = '# CHANGELOG    \n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
         changelog = utils.getChangelogForPr(pr)
       })
 
-      it('grabs the changelog text', () => {
+      it('should grab the changelog text', function () {
         expect(changelog).to.be.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
       })
     })

--- a/tests/vcs/bitbucket-server-spec.js
+++ b/tests/vcs/bitbucket-server-spec.js
@@ -1,14 +1,19 @@
 'use strict'
 
+const chai = require('chai')
 const rewire = require('rewire')
 const sinon = require('sinon')
-const expect = require('chai').expect
+const sinonChai = require('sinon-chai')
+const expect = chai.expect
+chai.use(sinonChai)
+
 const logger = require('../../lib/logger')
 const BitbucketServer = rewire('../../lib/vcs/bitbucket-server')
 
-describe('BitbucketServer', () => {
+describe('BitbucketServer', function () {
   let sandbox, bitbucket, config, fetchStub, revertFetchRewire
-  beforeEach(() => {
+
+  beforeEach(function () {
     sandbox = sinon.sandbox.create()
 
     // get rid of all logging messages in the tests (and let us test for them if we want)
@@ -41,26 +46,23 @@ describe('BitbucketServer', () => {
     bitbucket = new BitbucketServer(config)
   })
 
-  afterEach(() => {
-    // undo the rewiring
+  afterEach(function () {
     revertFetchRewire()
-
-    // remove all stubs/spies
     sandbox.restore()
   })
 
-  it('saves the config', () => {
+  it('should save the config', function () {
     expect(bitbucket.config).to.be.eql(config)
   })
 
-  it('constructs a base URL', () => {
+  it('should construct a base URL', function () {
     const url = 'https://ci-user:ci%20user%20password@bitbucket.my-domain.com/rest/api/1.0'
     expect(bitbucket.baseUrl).to.be.equal(url)
   })
 
-  describe('.getPr()', () => {
+  describe('.getPr()', function () {
     let resolution, rejection, promise, fetchResolver
-    beforeEach(() => {
+    beforeEach(function () {
       fetchResolver = {}
       let fetchPromise = new Promise((resolve, reject) => {
         fetchResolver.resolve = resolve
@@ -80,15 +82,13 @@ describe('BitbucketServer', () => {
         })
     })
 
-    it('calls fetch with proper params', () => {
-      expect(fetchStub.lastCall.args).to.be.eql([
-        `${bitbucket.baseUrl}/projects/me/repos/my-repo/pull-requests/5`
-      ])
+    it('should call fetch with proper params', function () {
+      expect(fetchStub).to.have.been.calledWith(`${bitbucket.baseUrl}/projects/me/repos/my-repo/pull-requests/5`)
     })
 
-    describe('when fetch succeeds', () => {
+    describe('when fetch succeeds', function () {
       let resp
-      beforeEach((done) => {
+      beforeEach(function (done) {
         resp = {ok: true, status: 200, json: function () {}}
         let pr = {
           id: 5,
@@ -111,7 +111,7 @@ describe('BitbucketServer', () => {
         fetchResolver.resolve(resp)
       })
 
-      it('resolves with the correct PR', () => {
+      it('should resolve with the correct PR', function () {
         expect(resolution).to.be.eql({
           description: 'This is a #fix#',
           headSha: 'sha-1',
@@ -121,8 +121,8 @@ describe('BitbucketServer', () => {
       })
     })
 
-    describe('when fetch errors', () => {
-      beforeEach((done) => {
+    describe('when fetch errors', function () {
+      beforeEach(function (done) {
         promise.catch(() => {
           done()
         })
@@ -130,21 +130,21 @@ describe('BitbucketServer', () => {
         fetchResolver.reject('my-error')
       })
 
-      it('passes up the error', () => {
+      it('should pass up the error', function () {
         expect(rejection).to.be.equal('my-error')
       })
     })
   })
 
-  describe('.addRemoteForPush()', () => {
+  describe('.addRemoteForPush()', function () {
     let remoteName
-    beforeEach(() => {
+    beforeEach(function () {
       return bitbucket.addRemoteForPush().then((name) => {
         remoteName = name
       })
     })
 
-    it('resolves with oritin', () => {
+    it('should resolve with oritin', function () {
       expect(remoteName).to.be.equal('origin')
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [x] #major# - incompatible API change

# CHANGELOG
 * **Fixed** #44 by throwing an error when `# CHANGELOG` is missing/empty unless `prependChangelog` is set to `false`.  This is a **breaking** change as previously missing `# CHANGELOG` sections would result in a default message in the `CHANGELOG.md` file. 
