### PR TITLE
Add dependency-snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ will know exactly what to do before the build fails.
 [bitbucket-url]: https://bitbucket.org/product/server
 [travis-url]: https://travis-ci.org
 [teamcity-url]: https://www.jetbrains.com/teamcity/
+
 ## Integrations
 `pr-bumper` currently supports pull requests on [GitHub][github-url], and [Bitbucket Server][bitbucket-url]
 
@@ -213,8 +214,42 @@ the `travis` provider (see below)
 Here you configure what CI system you use, the only currently supported options are `travis` (the default),
 or `teamcity`
 
+### `dependencySnapshotFile`
+`pr-bumper` will automatically use `npm shrinkwrap` to output a `dependency-snapshot.json` file for every release.
+This lets you see exactly what versions of all your dependencies were in use when that version was built. You can use
+the `dependencySnapshotFile` property in your `.pr-bumper.json` file to customize the name of the file generated, or
+by setting it to an empty string, you can disable that feature of `pr-bumper` completely.
+
+Customize dependency snapshot example:
+`.pr-bumper.json`
+```json
+{
+  "dependencySnapshotFile": "my-deps.json"
+}
+```
+
+Disable dependency snapshot example:
+`.pr-bumper.json`
+```json
+{
+  "dependencySnapshotFile": ""
+}
+```
+
 ### `owner`
 The Bitbucket project where your repository resides
+
+### `prependChangelog`
+Boolean whether to read the PR description to insert into CHANGELOG.md on bump. Defaults to `true`.
+
+Disable `prependChangelog` example:
+
+`.pr-bumper.json`
+  ```json
+  {
+    "prependChangelog": false
+  }
+  ```
 
 ### `repo`
 The name of your Bitbucket repository
@@ -229,15 +264,3 @@ repository in question.
 ### `vcs.provider`
 Here you configure what VCS system you use, the only currently supported options are `github` (the default),
 or `bitbucket-server`
-
-### `prependChangelog`
-Boolean whether to read the PR description to insert into CHANGELOG.md on bump. Defaults to `true`.
-
-Disable `prependChangelog` example:
-
-`.pr-bumper.json`
-  ```json
-  {
-    "prependChangelog": false
-  }
-  ```

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -61,6 +61,12 @@ class Bumper {
         return this._prependChangelog(info, 'CHANGELOG.md')
       })
       .then(() => {
+        if (this.config.dependencySnapshotFile === '') {
+          return Promise.resolve()
+        }
+        return this._generateDependencySnapshot()
+      })
+      .then(() => {
         return this._dependencies()
       })
       .then(() => {
@@ -132,13 +138,15 @@ class Bumper {
 
     return this.ci.setupGitEnv()
       .then(() => {
-        var adds = ['package.json', 'CHANGELOG.md']
-        var reportOutput = __.get(this.config, 'dependencies.output.directory')
+        // TODO: make this more configurable? (what's being bumped that is)
+        const adds = ['package.json', 'CHANGELOG.md']
+        if (this.config.dependencySnapshotFile !== '') {
+          adds.push(this.config.dependencySnapshotFile)
+        }
+        const reportOutput = __.get(this.config, 'dependencies.output.directory')
         if (reportOutput) {
           adds.push(`${reportOutput}/`)
         }
-        // TODO: make this more configurable? (what's being bumped that is)
-        console.log(`adding ${adds} to the git stage`)
         return this.ci.add(adds)
       })
       .then(() => {
@@ -173,6 +181,17 @@ class Bumper {
       return dependencies.run(cwd, absOutputPath, this.config)
     }
     return Promise.resolve('skipping dependencies')
+  }
+
+  /**
+   * Generate a dependency snapshot file by using `npm shrinkwrap`
+   * TODO: do we want to handle projects that include npm-shrinkwrap.json?
+   * @returns {Promise} a promise resolved when operation completes
+   */
+  _generateDependencySnapshot () {
+    return exec('npm shrinkwrap').then((out) => {
+      return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
+    })
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,6 +122,7 @@ const utils = {
           }
         ]
       },
+      dependencySnapshotFile: 'dependency-snapshot.json',
       vcs: {
         domain: 'github.com',
         env: {

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -78,6 +78,10 @@ function verifyGitHubTravisDefaults (ctx) {
         writeToken: '54321'
       })
     })
+
+    it('should default dependencySnapshotFile to "dependency-snapshot.json"', function () {
+      expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
+    })
   })
 }
 
@@ -131,6 +135,10 @@ function verifyBitbucketTeamcityOverrides (ctx) {
         writeToken: undefined
       })
     })
+
+    it('should default dependencySnapshotFile to "dependency-snapshot.json"', function () {
+      expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
+    })
   })
 }
 
@@ -154,7 +162,6 @@ describe('utils', function () {
     })
 
     afterEach(function () {
-      // restore the realEnv
       setEnv(realEnv)
     })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

NOTE: the link in the changelog description won't work until after the PR is merged, it's linking to the new `README.md` content. 

# CHANGELOG
* **Added** a `dependencySnapshotFile` property to `.pr-bumper.json` which defaults to `dependency-snapshot.json` more information available [here](https://github.com/ciena-blueplanet/pr-bumper#dependencysnapshotfile)
