### PR TITLE
Temporary fix - destructuring issue node 6.9.1

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -228,10 +228,10 @@ class Bumper {
     return this._getLastPr()
       .then((pr) => {
         return Promise.all([utils.getChangelogForPr(pr), utils.getScopeForPr(pr)])
-          .then(([changelog, scope]) => {
+          .then((params) => {
             return {
-              changelog,
-              scope
+              changelog: params[0],
+              scope: params[1]
             }
           })
       })
@@ -248,10 +248,10 @@ class Bumper {
         return Promise.all([
           this.config.prependChangelog ? utils.getChangelogForPr(pr) : Promise.resolve(''),
           utils.getScopeForPr(pr)
-        ]).then(([changelog, scope]) => {
+        ]).then((params) => {
           return {
-            changelog,
-            scope
+            changelog: params[0],
+            scope: params[1]
           }
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Some of our teamcity projects are using pr-bumper, but they are running on node 5.11.1 so they are having issues with destructuring. A temporary fix is to remove the destructuring until our teamcity build is using node >= 6.9.1

# CHANGELOG
* Remove destructuring to avoid problem on node 5.11.1