### PR TITLE
Add --dev to `npm shrinkwrap` command

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -189,7 +189,7 @@ class Bumper {
    * @returns {Promise} a promise resolved when operation completes
    */
   _generateDependencySnapshot () {
-    return exec('npm shrinkwrap').then((out) => {
+    return exec('npm shrinkwrap --dev').then((out) => {
       return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
     })
   }

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -477,7 +477,7 @@ describe('Bumper', function () {
     let ret
     beforeEach(function () {
       bumper.config.dependencySnapshotFile = 'snapshot-file'
-      execStub.withArgs('npm shrinkwrap').returns(Promise.resolve('shrinkwrap-done'))
+      execStub.withArgs('npm shrinkwrap --dev').returns(Promise.resolve('shrinkwrap-done'))
       execStub.returns(Promise.resolve('move-done'))
 
       return bumper._generateDependencySnapshot().then((resp) => {
@@ -486,7 +486,7 @@ describe('Bumper', function () {
     })
 
     it('should generate the dependency snapshot', function () {
-      expect(execStub).to.have.been.calledWith('npm shrinkwrap')
+      expect(execStub).to.have.been.calledWith('npm shrinkwrap --dev')
     })
 
     it('should rename the dependency snapshot', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** issue where `npm shrinkwrap` was being called w/o `--dev` so not all dependencies were actually being accounted for in the snapshot. This is particularly important in things like ember apps where everything is in `devDependencies`. 
