### PR TITLE
Prune node_modules before shrinkwrap

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -189,9 +189,16 @@ class Bumper {
    * @returns {Promise} a promise resolved when operation completes
    */
   _generateDependencySnapshot () {
-    return exec('npm shrinkwrap --dev').then((out) => {
-      return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
-    })
+    // We need to do the prune b/c of the following issue with npm-shrinkwrap
+    // https://github.com/SaltwaterC/aws2js/issues/58, apparently one of our deps
+    // installs things w/o having them in package.json, causing npm shrinkwrap to barf
+    return exec('npm prune')
+      .then(() => {
+        return exec('npm shrinkwrap --dev')
+      })
+      .then(() => {
+        return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
+      })
   }
 
   /**

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -477,12 +477,17 @@ describe('Bumper', function () {
     let ret
     beforeEach(function () {
       bumper.config.dependencySnapshotFile = 'snapshot-file'
+      execStub.withArgs('npm prune').returns(Promise.resolve('prune-done'))
       execStub.withArgs('npm shrinkwrap --dev').returns(Promise.resolve('shrinkwrap-done'))
       execStub.returns(Promise.resolve('move-done'))
 
       return bumper._generateDependencySnapshot().then((resp) => {
         ret = resp
       })
+    })
+
+    it('should prune node_modules so shrinkwrap will work', function () {
+      expect(execStub).to.have.been.calledWith('npm prune')
     })
 
     it('should generate the dependency snapshot', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** an issue with running `npm shrinkwrap` that arises when some package installs things into `node_modules` that isn't in `package.json` by doing an `npm prune` before `npm shrinkwrap`
