### PR TITLE
Try to add slack support for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+codecov:
+  notify:
+    require_ci_to_pass: true
+
+comment:
+  behavior: default
+  layout: header, diff
+  require_changes: false
+
+coverage:
+  precision: 2
+  range:
+  - 70.0
+  - 100.0
+  round: down
+
+  notify:
+    slack:
+      default:
+        url: "secret:7nPkTf4F6pXCGy4tmrUGF0RIucl8fFqDjwmME8dZkFU4TG50OEZQ8PixqmotsmW6vWhduks7ohzqQbMAknOFGwjj+MzX3iIyGpYA12f87ILwAmsTY7Dn4ZAbxUSyPmaNoQivmKwg8mDpJBOE7y0XO8SOElN7zlrEMVinlCuCG28="
+
+  status:
+    changes: false
+    patch: true
+    project: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      macro: false
+      method: false
+
+  javascript:
+    enable_partials: false
+
+


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** slack integration for codecov.io