### PR TITLE
Add support for #none# version bump option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 ### This project uses [semver](semver.org), please check the scope of this pr:
+ - [ ] #none# - documentation fixes and/or test additions
  - [ ] #patch# - backwards-compatible bug fix
  - [ ] #minor# - adding functionality in a backwards-compatible manner
  - [ ] #major# - incompatible API change

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
     secure: MMMrKAVIbU7ZzCTeOfgRGSUPJx0s0DBDS/zLwYcOdwMDsJZuZqLKVcm7rXj6srTHIGMpwzP5FTID9S2sHuVHtnqOfOByeJB0AvlBkHNQMgqKQvSCQxzMwbVz7FCFMaFQDkL2o3aKeQV2I5mxXfT+/xXYHTZfdDuzkFD4mI9ygaP+EPJnDIwf5ckxhhcXj0Rckpz8X/ZgS/owQLcTicKzly96378im77Nl6KBe585E+9Om79F7GHlewa+D0Hz2gLoX61RnXvsKG4HUrEZDF5TY0RIwxkvYMEQuPA6rDDjN2qnMuZAdNqVT74sSG8cGF8D/J4RVUQ9IssSltrRgBwPa+lnmfmL9+sxCwW5GY+VoKUbIh3kJkcfN1xxFCOAnTPxqj9Mmi1Zad/NRe1dniClKoMxm0IYUM7ZevXooLhOhCfkGOfXgibv+MHoQ4IyicIjS2K7xcJLLX5HSumnv8wD0iQuRCF9mpp1iyLHmVf/g0vo7HURt+PN8sSh1F8nirJ2zUCtp5NWBc21MhOQEUmPng/lC350NInMoKpO7SZHBKn+qzpKRARCoYJfiyQ4G9i/F29B9pa+fAKYnYEO1d+OfBIbR1FbTzbgwt1sHUYoDNYRaGKUzt0Q+atveZbA37mN197P0eu5/2ENA1gSVwE6+w71FQPb+pGw3Gu4bRVPJnc=
   on:
     branch: master
-    tags: false
+    tags: true
     node: '6.9.1'
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use text from a pull request description to automatically bump the version numbe
 `pr-bumper` uses [Semantic Versioning](http://semver.org/).
 
 Pull requests must include a directive indicating the
-scope of the change being made (`major`/`minor`/`patch`). Directives are **case insensitive** and wrapped in `#` to
+scope of the change being made (`major`/`minor`/`patch`/`none`). Directives are **case insensitive** and wrapped in `#` to
 avoid a description such as
 
 ```
@@ -31,6 +31,7 @@ We also support the aliases of `breaking`, `feature`, and `fix`.
 
 | Starting Version | Directive    | Ending Version |
 | :--------------: | :----------- | :------------: |
+| 1.2.3            | `#none#`     | 1.2.3          |
 | 1.2.3            | `#patch#`    | 1.2.4          |
 | 1.2.3            | `#fix#`      | 1.2.4          |
 | 1.2.3            | `#minor#`    | 1.3.0          |
@@ -47,6 +48,7 @@ You may also specify a list of possible scopes in a [GFM checklist][gfm-checklis
  Example:
 
  ### This project uses [semver](semver.org), please check the scope of this pr:
+ - [ ] #none# - documentation fixes and/or test additions
  - [ ] #patch# - backwards-compatible bug fix
  - [ ] #minor# - adding functionality in a backwards-compatible manner
  - [x] #major# - incompatible API change

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -262,22 +262,21 @@ class Bumper {
     const vcs = this.vcs
     return vcs.getPr(this.config.prNumber)
       .then((pr) => {
-        return utils.getScopeForPr(pr)
-          .then((scope) => {
-            if (!this.config.prependChangelog || scope === 'none') {
-              return Promise.resolve({
-                changelog: '',
-                scope: scope
-              })
-            }
+        const scope = utils.getScopeForPr(pr)
 
-            return utils.getChangelogForPr(pr)
-              .then((changelog) => {
-                return Promise.resolve({
-                  changelog: changelog,
-                  scope: scope
-                })
-              })
+        if (!this.config.prependChangelog || scope === 'none') {
+          return {
+            changelog: '',
+            scope: scope
+          }
+        }
+
+        return utils.getChangelogForPr(pr)
+          .then((changelog) => {
+            return {
+              changelog: changelog,
+              scope: scope
+            }
           })
       })
   }

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -262,15 +262,23 @@ class Bumper {
     const vcs = this.vcs
     return vcs.getPr(this.config.prNumber)
       .then((pr) => {
-        return Promise.all([
-          this.config.prependChangelog ? utils.getChangelogForPr(pr) : Promise.resolve(''),
-          utils.getScopeForPr(pr)
-        ]).then((params) => {
-          return {
-            changelog: params[0],
-            scope: params[1]
-          }
-        })
+        return utils.getScopeForPr(pr)
+          .then((scope) => {
+            if (!this.config.prependChangelog || scope === 'none') {
+              return {
+                changelog: '',
+                scope: scope
+              }
+            }
+
+            return utils.getChangelogForPr(pr)
+              .then((changelog) => {
+                return {
+                  changelog: changelog,
+                  scope: scope
+                }
+              })
+          })
       })
   }
 

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -55,28 +55,35 @@ class Bumper {
         return this._bumpVersion(info, 'package.json')
       })
       .then((info) => {
-        if (!this.config.prependChangelog) {
+        if (!info.version) {
           return Promise.resolve()
         }
-        return this._prependChangelog(info, 'CHANGELOG.md')
-      })
-      .then(() => {
-        if (this.config.dependencySnapshotFile === '') {
-          return Promise.resolve()
-        }
-        return this._generateDependencySnapshot()
-      })
-      .then(() => {
-        return this._dependencies()
-      })
-      .then(() => {
-        return this._commitChanges()
-      })
-      .then(() => {
-        return this._createTag()
-      })
-      .then(() => {
-        return this.ci.push(this.vcs)
+
+        return Promise.resolve(info)
+          .then((info) => {
+            if (!this.config.prependChangelog) {
+              return Promise.resolve()
+            }
+            return this._prependChangelog(info, 'CHANGELOG.md')
+          })
+          .then(() => {
+            if (this.config.dependencySnapshotFile === '') {
+              return Promise.resolve()
+            }
+            return this._generateDependencySnapshot()
+          })
+          .then(() => {
+            return this._dependencies()
+          })
+          .then(() => {
+            return this._commitChanges()
+          })
+          .then(() => {
+            return this._createTag()
+          })
+          .then(() => {
+            return this.ci.push(this.vcs)
+          })
       })
   }
 
@@ -120,7 +127,7 @@ class Bumper {
         break
 
       case 'none':
-        break
+        return info
 
       default:
         throw new Error(`pr-bumper: Invalid scope [${info.scope}]`)

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -263,21 +263,12 @@ class Bumper {
     return vcs.getPr(this.config.prNumber)
       .then((pr) => {
         const scope = utils.getScopeForPr(pr)
+        const getChangelog = this.config.prependChangelog && scope !== 'none'
 
-        if (!this.config.prependChangelog || scope === 'none') {
-          return {
-            changelog: '',
-            scope: scope
-          }
+        return {
+          changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
+          scope: scope
         }
-
-        return utils.getChangelogForPr(pr)
-          .then((changelog) => {
-            return {
-              changelog: changelog,
-              scope: scope
-            }
-          })
       })
   }
 

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -119,6 +119,9 @@ class Bumper {
         v.newMajor()
         break
 
+      case 'none':
+        break
+
       default:
         throw new Error(`pr-bumper: Invalid scope [${info.scope}]`)
     }

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -265,18 +265,18 @@ class Bumper {
         return utils.getScopeForPr(pr)
           .then((scope) => {
             if (!this.config.prependChangelog || scope === 'none') {
-              return {
+              return Promise.resolve({
                 changelog: '',
                 scope: scope
-              }
+              })
             }
 
             return utils.getChangelogForPr(pr)
               .then((changelog) => {
-                return {
+                return Promise.resolve({
                   changelog: changelog,
                   scope: scope
-                }
+                })
               })
           })
       })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,7 +140,7 @@ const utils = {
   },
 
   /**
-   * Make sure scope is one of 'patch', 'minor', 'major' (or their aliases)
+   * Make sure scope is one of 'patch', 'minor', 'major', 'none' (or their aliases)
    *
    * @param {String} scope - the scope to check
    * @param {String} prNumber - the # of the PR
@@ -155,7 +155,8 @@ const utils = {
       feature: 'minor',
       minor: 'minor',
       breaking: 'major',
-      major: 'major'
+      major: 'major',
+      none: 'none'
     }
 
     const validatedScope = scopeLookup[scope]
@@ -168,7 +169,7 @@ const utils = {
   },
 
   /**
-   * Extract the scope string ('patch', 'minor', 'major') from the PR object
+   * Extract the scope string ('patch', 'minor', 'major', 'none') from the PR object
    * @param {PullRequest} pr - the PR object
    * @returns {String} the scope of the PR (from the pr description)
    * @throws Error if there is not a single, valid scope in the PR description

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -625,7 +625,7 @@ describe('Bumper', function () {
       bumper.vcs = {getPr: function () {}}
 
       sandbox.stub(bumper.vcs, 'getPr').returns(Promise.resolve('the-pr'))
-      sandbox.stub(utils, 'getScopeForPr').returns(Promise.resolve('patch'))
+      sandbox.stub(utils, 'getScopeForPr').returns('patch')
       sandbox.stub(utils, 'getChangelogForPr').returns(Promise.resolve('the-changelog'))
     })
 

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -626,7 +626,7 @@ describe('Bumper', function () {
 
       sandbox.stub(bumper.vcs, 'getPr').returns(Promise.resolve('the-pr'))
       sandbox.stub(utils, 'getScopeForPr').returns('patch')
-      sandbox.stub(utils, 'getChangelogForPr').returns(Promise.resolve('the-changelog'))
+      sandbox.stub(utils, 'getChangelogForPr').returns('the-changelog')
     })
 
     describe('when prependChangelog is set', function () {

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -49,9 +49,15 @@ function testBumpVersion (ctx, scope, expectedVersion) {
       expect(newVersion).to.be.equal(expectedVersion)
     })
 
-    it('should return the correct version', function () {
-      expect(info.version).to.be.equal(expectedVersion)
-    })
+    if (scope === 'none') {
+      it('should not include the version', function () {
+        expect(info.version).to.equal(undefined)
+      })
+    } else {
+      it('should return the correct version', function () {
+        expect(info.version).to.be.equal(expectedVersion)
+      })
+    }
   })
 }
 

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -310,6 +310,7 @@ describe('Bumper', function () {
       return exec('rm -f _package.json')
     })
 
+    testBumpVersion(ctx, 'none', '1.2.3')
     testBumpVersion(ctx, 'patch', '1.2.4')
     testBumpVersion(ctx, 'minor', '1.3.0')
     testBumpVersion(ctx, 'major', '2.0.0')

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -329,7 +329,8 @@ describe('utils', function () {
       feature: 'minor',
       minor: 'minor',
       breaking: 'major',
-      major: 'major'
+      major: 'major',
+      none: 'none'
     }
 
     __.forIn(scopes, (value, key) => {
@@ -405,6 +406,7 @@ describe('utils', function () {
       beforeEach(function () {
         pr.description = `
 ### Check the scope of this pr:
+- [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - bugfix, dependency update
 - [x] #minor# - new feature, backwards compatible
 - [ ] #major# - major feature, probably breaking API


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

resolves #49 

# CHANGELOG

* **Added** support for new `#none#` scope to support pull requests that do not bump the version resolving [#49](https://github.com/ciena-blueplanet/pr-bumper/issues/49) and [#40](https://github.com/ciena-blueplanet/pr-bumper/issues/40) (with the use of `tags: true` in `.travis.yml`)
