### PR TITLE
Fix ci publish

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,8 +4,8 @@
 
 const program = require('commander')
 const pkgJson = require('../package.json')
+const Bumper = require('../lib/bumper')
 const Cli = require('../lib/cli')
-
 const cli = new Cli()
 
 program
@@ -17,6 +17,9 @@ program
       .catch((error) => {
         const msg = (error.message) ? error.message : error
         console.log(msg)
+        if (error instanceof Bumper.Cancel) {
+          process.exit(0)
+        }
         process.exit(1)
       })
   })

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -20,6 +20,12 @@ const pkgJson = require('../package.json')
 const logger = require('./logger')
 const utils = require('./utils')
 
+class Cancel {
+  constructor (message) {
+    this.message = message
+  }
+}
+
 /**
  * Interacts with a Vcs to achieive a version bump
  * @class
@@ -50,40 +56,48 @@ class Bumper {
       return Promise.resolve()
     }
 
-    return this._getMergedPrInfo()
+    return this.vcs.getLastCommitMsg()
+      .then((commitMessage) => {
+        if (commitMessage === 'Automated version bump') {
+          throw new Cancel('Skipping bump on version bump commit.')
+        }
+        return Promise.resolve()
+      })
+      .then(() => {
+        return this._getMergedPrInfo()
+      })
       .then((info) => {
         return this._bumpVersion(info, 'package.json')
       })
       .then((info) => {
         if (!info.version) {
+          throw new Cancel('Skipping bump commit since version did not change.')
+        }
+
+        if (!this.config.prependChangelog) {
+          logger.log('Skipping prepending changelog because of config option.')
           return Promise.resolve()
         }
 
-        return Promise.resolve(info)
-          .then((info) => {
-            if (!this.config.prependChangelog) {
-              return Promise.resolve()
-            }
-            return this._prependChangelog(info, 'CHANGELOG.md')
-          })
-          .then(() => {
-            if (this.config.dependencySnapshotFile === '') {
-              return Promise.resolve()
-            }
-            return this._generateDependencySnapshot()
-          })
-          .then(() => {
-            return this._dependencies()
-          })
-          .then(() => {
-            return this._commitChanges()
-          })
-          .then(() => {
-            return this._createTag()
-          })
-          .then(() => {
-            return this.ci.push(this.vcs)
-          })
+        return this._prependChangelog(info, 'CHANGELOG.md')
+      })
+      .then(() => {
+        if (this.config.dependencySnapshotFile === '') {
+          return Promise.resolve()
+        }
+        return this._generateDependencySnapshot()
+      })
+      .then(() => {
+        return this._dependencies()
+      })
+      .then(() => {
+        return this._commitChanges()
+      })
+      .then(() => {
+        return this._createTag()
+      })
+      .then(() => {
+        return this.ci.push(this.vcs)
       })
   }
 
@@ -160,7 +174,7 @@ class Bumper {
         return this.ci.add(adds)
       })
       .then(() => {
-        return this.ci.commit('Automated version bump [ci skip]', `From CI build ${buildNumber}`)
+        return this.ci.commit('Automated version bump', `From CI build ${buildNumber}`)
       })
   }
 
@@ -283,5 +297,7 @@ class Bumper {
     return prepend(changelogFile, data)
   }
 }
+
+Bumper.Cancel = Cancel
 
 module.exports = Bumper

--- a/lib/ci/base.js
+++ b/lib/ci/base.js
@@ -47,6 +47,10 @@ class CiBase {
     return exec(`git commit -m "${summary}" -m "${message}"`)
   }
 
+  getLastCommitMsg () {
+    return exec('git log --pretty=format:\'%s\' -1')
+  }
+
   /**
    * Push local changes to remote repo
    * @returns {Promise} a promise resolved with the result of the push


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Changed** the commit message for bump commits to no longer include `[ci skip]` in the commit message, this means that version bump commits will now trigger additional travis builds. If this works, I'll update the `README.md` with instructions on how to support `#none#` properly in your travis config. 