### PR TITLE
Stop using the magic skip me commit message

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -58,7 +58,7 @@ class Bumper {
 
     return this.ci.getLastCommitMsg()
       .then((commitMessage) => {
-        if (commitMessage === 'Automated version bump [ci skip]') {
+        if (commitMessage === 'Automated version bump') {
           throw new Cancel('Skipping bump on version bump commit.')
         }
         return Promise.resolve()
@@ -174,7 +174,7 @@ class Bumper {
         return this.ci.add(adds)
       })
       .then(() => {
-        return this.ci.commit('Automated version bump [ci skip]', `From CI build ${buildNumber}`)
+        return this.ci.commit('Automated version bump', `From CI build ${buildNumber}`)
       })
   }
 

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -326,7 +326,7 @@ describe('Bumper', function () {
 
     describe('when last commit was automated version bump', function () {
       beforeEach(function (done) {
-        bumper.ci.getLastCommitMsg.returns(Promise.resolve('Automated version bump [ci skip]'))
+        bumper.ci.getLastCommitMsg.returns(Promise.resolve('Automated version bump'))
         bumper.bump()
           .then((res) => {
             result = res
@@ -572,7 +572,7 @@ describe('Bumper', function () {
       })
 
       it('should commits the changes', function () {
-        const summary = 'Automated version bump [ci skip]'
+        const summary = 'Automated version bump'
         const message = 'From CI build 12345'
 
         expect(bumper.ci.commit).to.have.been.calledWith(summary, message)
@@ -601,7 +601,7 @@ describe('Bumper', function () {
       })
 
       it('should commits the changes', function () {
-        const summary = 'Automated version bump [ci skip]'
+        const summary = 'Automated version bump'
         const message = 'From CI build 12345'
 
         expect(bumper.ci.commit).to.have.been.calledWith(summary, message)
@@ -733,7 +733,7 @@ describe('Bumper', function () {
         'fa066f2 Removed newline from parsed PR number\n' +
         'fc416cc Merge pull request #29 from job13er/make-bumping-more-robust\n' +
         '67db358 Fix for #26 by reading PR # from git commit\n' +
-        '4a61a20 Automated version bump [ci skip]\n' +
+        '4a61a20 Automated version bump\n' +
         '7db44e1 Merge pull request #24 from sandersky/master\n' +
         'f571451 add pullapprove config\n' +
         '4398a26 address PR concerns\n'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Stopped** adding `[ci skip]` to commit messages to try to get tags to build