### PR TITLE
Allow consumers to specify publish version of node

### DIFF
--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -7,9 +7,9 @@ then
   exit 0
 fi
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-6.9.1}" ]
 then
-  echo "Skipping pr-bumper for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  echo "Skipping pr-bumper for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
   exit 0
 fi
 

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-6.9.1}" ]
 then
-  echo "Skipping coverage publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  echo "Skipping coverage publish for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
   exit 0
 fi
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the following snippet to your `.travis.yml` file to integrate `pr-bumper`
 
   ```yaml
   before_install:
-    - npm install -g pr-bumper
+    - npm install -g pr-bumper@^1.0.0
 
   install:
     - $(npm root -g)/pr-bumper/.travis/maybe-install.sh


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** ability to override the default `node` version that will be used for publishing via the `PUBLISH_NODE_VERSION` environment variable in `.travis/` scripts provided by `pr-bumper`
  ```bash
  PUBLISH_NODE_VERSION=stable $(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh
  ```

  can be used to switch the `node` version that used for bumping from `6.9.1` to `stable`
* **Updated** `README.md` to suggest installing `pr-bumper` with a version scope, to protect against future breaking changes