### PR TITLE
Improve logic around applying defaults

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,26 @@ const __ = require('lodash')
 const logger = require('./logger')
 
 /**
+ * Walk the properties of an object (recursively) while converting it to a flat representation of the leaves of the
+ * object (properties with primitive, non-object types which need their default value set).
+ * representing the leaves (the actual values that need defaults)
+ * @param {String} prefix - the key prefix for the object being processed
+ * @param {Object} object - the complex, nested object of default values currently being processed
+ * @param {Object} leaves - the simple key-value mapping of object path -> value
+ */
+function walkObject (prefix, object, leaves) {
+  Object.keys(object).forEach((key) => {
+    const value = object[key]
+    const fullPrefix = (prefix) ? prefix + '.' + key : key
+    if (__.isObject(value) && !__.isArray(value)) {
+      walkObject(fullPrefix, value, leaves)
+    } else {
+      leaves[fullPrefix] = value
+    }
+  })
+}
+
+/**
  * Given a PR description, find the index of the # CHANGELOG section
  * @param {String[]} lines - lines in the pr description
  * @returns {Number} the index of the # CHANGELOG section (or -1)
@@ -36,20 +56,30 @@ function getChangelogSectionIndex (lines) {
 }
 
 /**
+ * Get the given key from process.env, substituting "undefined" for the real undefined
+ * @param {String} key - the environment variable we want to get
+ * @returns {*} whatever is at process.env[key] with the one exception of "undefined" being translated to undefined
+ */
+function getEnv (key) {
+  const value = process.env[key]
+  return (value === 'undefined') ? undefined : value
+}
+
+/**
  * Process the environment variable sections in the config and fill in the computed properties within it
  * @param {Config} config - the config object to process (will be mutated in-place)
  */
 function processEnv (config) {
   // Grab the CI stuff from env
-  config.ci.buildNumber = process.env[config.ci.env.buildNumber]
-  config.prNumber = process.env[config.ci.env.pr]
+  config.ci.buildNumber = getEnv(config.ci.env.buildNumber)
+  config.prNumber = getEnv(config.ci.env.pr)
   config.isPr = config.prNumber !== 'false'
-  config.branch = process.env[config.ci.env.branch] || 'master'
+  config.branch = getEnv(config.ci.env.branch) || 'master'
 
   logger.log(`pr-bumper::config: prNumber [${config.prNumber}], isPr [${config.isPr}]`)
 
   // Fill in the owner/repo from the repo slug in env if necessary
-  const repoSlug = process.env[config.ci.env.repoSlug]
+  const repoSlug = getEnv(config.ci.env.repoSlug)
 
   if (repoSlug) {
     const parts = repoSlug.split('/')
@@ -64,10 +94,10 @@ function processEnv (config) {
 
   // Grab the VCS stuff from the env
   config.vcs.auth = {
-    password: process.env[config.vcs.env.password],
-    readToken: process.env[config.vcs.env.readToken],
-    username: process.env[config.vcs.env.username],
-    writeToken: process.env[config.vcs.env.writeToken]
+    password: getEnv(config.vcs.env.password),
+    readToken: getEnv(config.vcs.env.readToken),
+    username: getEnv(config.vcs.env.username),
+    writeToken: getEnv(config.vcs.env.writeToken)
   }
 }
 
@@ -86,7 +116,8 @@ const utils = {
       logger.log('No .pr-bumper.json found, using defaults')
     }
 
-    __.defaults(config, {
+    const leaves = {}
+    const defaults = {
       ci: {
         env: {
           branch: 'TRAVIS_BRANCH',
@@ -111,16 +142,7 @@ const utils = {
           reposFile: 'repos',
           ignoreFile: 'ignore'
         },
-        additionalRepos: [
-          {
-            pattern: '\\s+"(ember\\-frost\\-\\S+)"',
-            url: 'https://github.com/ciena-frost/${REPO_NAME}.git'
-          },
-          {
-            pattern: '\\s+"(frost\\-\\S+)"',
-            url: 'https://bitbucket.ciena.com/scm/bp_frost/${REPO_NAME}.git'
-          }
-        ]
+        additionalRepos: []
       },
       dependencySnapshotFile: 'dependency-snapshot.json',
       vcs: {
@@ -132,6 +154,14 @@ const utils = {
         provider: 'github'
       },
       prependChangelog: true
+    }
+
+    walkObject('', defaults, leaves)
+    Object.keys(leaves).forEach((key) => {
+      const value = leaves[key]
+      if (__.get(config, key) === undefined) {
+        __.set(config, key, value)
+      }
     })
 
     processEnv(config)

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -47,7 +47,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       config = ctx.config
     })
 
-    if (!propsToSkip.indexOf('ci.gitUser') > -1) {
+    if (propsToSkip.indexOf('ci.gitUser') === -1) {
       it('should use the proper git user', function () {
         expect(config.ci.gitUser).to.be.eql({
           email: 'travis.ci.ciena@gmail.com',
@@ -56,43 +56,43 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       })
     }
 
-    if (!propsToSkip.indexOf('ci.provider') > -1) {
+    if (propsToSkip.indexOf('ci.provider') === -1) {
       it('should use the proper ci provider', function () {
         expect(config.ci.provider).to.be.equal('travis')
       })
     }
 
-    if (!propsToSkip.indexOf('owner') > -1) {
+    if (propsToSkip.indexOf('owner') === -1) {
       it('should have the proper owner', function () {
         expect(config.owner).to.be.equal('jdoe')
       })
     }
 
-    if (!propsToSkip.indexOf('branch') > -1) {
+    if (propsToSkip.indexOf('branch') === -1) {
       it('should have the proper branch', function () {
         expect(config.branch).to.be.equal('my-branch')
       })
     }
 
-    if (!propsToSkip.indexOf('repo') > -1) {
+    if (propsToSkip.indexOf('repo') === -1) {
       it('should have the proper repo', function () {
         expect(config.repo).to.be.equal('john-and-jane')
       })
     }
 
-    if (!propsToSkip.indexOf('vcs.domain') > -1) {
+    if (propsToSkip.indexOf('vcs.domain') === -1) {
       it('should have the proper vcs domain', function () {
         expect(config.vcs.domain).to.be.equal('github.com')
       })
     }
 
-    if (!propsToSkip.indexOf('vcs.provider') > -1) {
+    if (propsToSkip.indexOf('vcs.provider') === -1) {
       it('should have the proper vcs provider', function () {
         expect(config.vcs.provider).to.be.equal('github')
       })
     }
 
-    if (!propsToSkip.indexOf('vcs.auth') > -1) {
+    if (propsToSkip.indexOf('vcs.auth') === -1) {
       it('should have the proper vcs auth', function () {
         expect(config.vcs.auth).to.be.eql({
           password: undefined,
@@ -103,7 +103,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       })
     }
 
-    if (!propsToSkip.indexOf('dependencySnapshotFile') > -1) {
+    if (propsToSkip.indexOf('dependencySnapshotFile') === -1) {
       it('should default dependencySnapshotFile to "dependency-snapshot.json"', function () {
         expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
       })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -47,7 +47,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       config = ctx.config
     })
 
-    if (!propsToSkip.includes('ci.gitUser')) {
+    if (!propsToSkip.indexOf('ci.gitUser') > -1) {
       it('should use the proper git user', function () {
         expect(config.ci.gitUser).to.be.eql({
           email: 'travis.ci.ciena@gmail.com',
@@ -56,43 +56,43 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       })
     }
 
-    if (!propsToSkip.includes('ci.provider')) {
+    if (!propsToSkip.indexOf('ci.provider') > -1) {
       it('should use the proper ci provider', function () {
         expect(config.ci.provider).to.be.equal('travis')
       })
     }
 
-    if (!propsToSkip.includes('owner')) {
+    if (!propsToSkip.indexOf('owner') > -1) {
       it('should have the proper owner', function () {
         expect(config.owner).to.be.equal('jdoe')
       })
     }
 
-    if (!propsToSkip.includes('branch')) {
+    if (!propsToSkip.indexOf('branch') > -1) {
       it('should have the proper branch', function () {
         expect(config.branch).to.be.equal('my-branch')
       })
     }
 
-    if (!propsToSkip.includes('repo')) {
+    if (!propsToSkip.indexOf('repo') > -1) {
       it('should have the proper repo', function () {
         expect(config.repo).to.be.equal('john-and-jane')
       })
     }
 
-    if (!propsToSkip.includes('vcs.domain')) {
+    if (!propsToSkip.indexOf('vcs.domain') > -1) {
       it('should have the proper vcs domain', function () {
         expect(config.vcs.domain).to.be.equal('github.com')
       })
     }
 
-    if (!propsToSkip.includes('vcs.provider')) {
+    if (!propsToSkip.indexOf('vcs.provider') > -1) {
       it('should have the proper vcs provider', function () {
         expect(config.vcs.provider).to.be.equal('github')
       })
     }
 
-    if (!propsToSkip.includes('vcs.auth')) {
+    if (!propsToSkip.indexOf('vcs.auth') > -1) {
       it('should have the proper vcs auth', function () {
         expect(config.vcs.auth).to.be.eql({
           password: undefined,
@@ -103,7 +103,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
       })
     }
 
-    if (!propsToSkip.includes('dependencySnapshotFile')) {
+    if (!propsToSkip.indexOf('dependencySnapshotFile') > -1) {
       it('should default dependencySnapshotFile to "dependency-snapshot.json"', function () {
         expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
       })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -33,7 +33,11 @@ function setEnv (env) {
  * @param {Object} ctx - the context object for the tests
  * @param {String[]} propsToSkip - an array of string properties to skip the check for (if they've been overwritten)
  */
-function verifyGitHubTravisDefaults (ctx, propsToSkip = []) {
+function verifyGitHubTravisDefaults (ctx, propsToSkip) {
+  if (propsToSkip === undefined) {
+    propsToSkip = []
+  }
+
   // NOTE: disabling complexity check here b/c it's just complaining about the conditionals around
   // all the it() blocks now, but they're necessary to test overrides
   /* eslint-disable complexity */


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Improved** application of default values when processing `.pr-bumper.json`. Whereas previously you would have to provide an entire, complex, nested object if you wanted to override the default for any part of a config object, you can now override a partial object in your `.pr-bumper.json` and the rest of the object will get the appropriate defaults. 
