### PR TITLE
Add coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
 - .travis/maybe-check-scope.sh
 script:
 - .travis/maybe-test.sh
+- .travis/maybe-check-coverage.sh
 - .travis/maybe-bump-version.sh
 after_success:
 - .travis/maybe-publish-coverage.sh

--- a/.travis/is-bump-commit.sh
+++ b/.travis/is-bump-commit.sh
@@ -2,7 +2,7 @@
 
 isBumpCommit() {
   msg=`git log --pretty=format:'%s' -1`
-  if [ "$msg" = "Automated version bump" ]
+  if [[ "$msg" =~ ^\[pr-bumper\]* ]]
   then
     # totally un-intuitive, but returning 0 evaluates to true when put in a if
     # http://stackoverflow.com/a/5431932

--- a/.travis/maybe-check-coverage.sh
+++ b/.travis/maybe-check-coverage.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source $(dirname $0)/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping pr-bumper check-coverage step for version bump commit"
+  exit 0
+fi
+
+PACKAGE_NAME=$(node -p -e "require('./package.json').name")
+
+if [ "$PACKAGE_NAME" == "pr-bumper" ]
+then
+  VERBOSE=1 ./bin/cli.js check-coverage
+else
+  pr-bumper check-coverage
+fi

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ will know exactly what to do before the build fails.
 [travis-url]: https://travis-ci.org
 [teamcity-url]: https://www.jetbrains.com/teamcity/
 
+### Code Coverage
+`pr-bumper` supports ensuring that code coverage is not decreasing because of a pull request. This is achieved by
+comparing the current code coverage against a saved "baseline" coverage percentage. Enabling this feature is done
+by providing `pr-bumper` with the "baseline" coverage percentage in `package.json`, by adding the following:
+
+```json
+"pr-bumper": {
+  "coverage": 85.93
+}
+```
+
+That would indicate to `pr-bumper` that the current coverage for your repository is `85.93` percent, so any coverage
+below that will fail the `pr-bumper check-coverage` check, and can then fail your CI build if you include the running
+of `pr-bumper check-coverage` in your CI (after your tests run and coverage is reported of course).
+
+The "current" coverage that `pr-bumper` will compare against this "baseline" will be read from the file at `coverage/coverage-summary.json`. This can be populated using the `json-summary` reporter from `istanbul`.
+There are a number of statistics in `coverage-summary.json`, but the one that `pr-bumper` looks at is the total
+percentage of lines covered, or `total.lines.pct`.
+
 ## Integrations
 `pr-bumper` currently supports pull requests on [GitHub][github-url], and [Bitbucket Server][bitbucket-url]
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,7 +16,7 @@ program
       .run(cmd, options)
       .catch((error) => {
         const msg = (error.message) ? error.message : error
-        console.log(msg)
+        console.log(`${pkgJson.name}: ERROR: ${msg}`)
         if (error instanceof Bumper.Cancel) {
           process.exit(0)
         }

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -8,6 +8,9 @@ const prependFile = require('prepend-file')
 const Promise = require('promise')
 const versiony = require('versiony')
 const path = require('path')
+const fsWriteFile = require('fs').writeFile
+
+const pkgJson = require('../package.json')
 
 // Compliance implementation
 let dependencies = require('./compliance/dependencies')
@@ -15,9 +18,22 @@ let dependencies = require('./compliance/dependencies')
 // using let so stuff can be rewired in the test
 let exec = Promise.denodeify(cpExec)
 let prepend = Promise.denodeify(prependFile)
+let writeFile = Promise.denodeify(fsWriteFile)
 
 const logger = require('./logger')
 const utils = require('./utils')
+
+/**
+ * Adds the given filename to info.modifiedFiles if it doesn't already exist
+ * @param {PrInfo} info - the info for the PR
+ * @param {String[]} info.modifiedFiles - the list of modified files so far
+ * @param {String} filename - the filename to add to info.modifiedFiles if it's not already there
+ */
+function addModifiedFile (info, filename) {
+  if (!info.modifiedFiles.includes(filename)) {
+    info.modifiedFiles.push(filename)
+  }
+}
 
 class Cancel {
   constructor (message) {
@@ -57,8 +73,8 @@ class Bumper {
 
     return this.ci.getLastCommitMsg()
       .then((commitMessage) => {
-        if (commitMessage === 'Automated version bump') {
-          throw new Cancel('Skipping bump on version bump commit.')
+        if (commitMessage.startsWith(`[${pkgJson.name}]`)) {
+          throw new Cancel(`Skipping bump on ${pkgJson.name} commit.`)
         }
         return Promise.resolve()
       })
@@ -66,37 +82,28 @@ class Bumper {
         return this._getMergedPrInfo()
       })
       .then((info) => {
-        return this._bumpVersion(info, 'package.json')
+        return this._maybeBumpVersion(info, 'package.json')
       })
       .then((info) => {
-        if (!info.version) {
-          throw new Cancel('Skipping bump commit since version did not change.')
-        }
-
-        if (!this.config.prependChangelog) {
-          logger.log('Skipping prepending changelog because of config option.')
-          return Promise.resolve()
-        }
-
-        return this._prependChangelog(info, 'CHANGELOG.md')
+        return this._maybePrependChangelog(info)
       })
-      .then(() => {
-        if (this.config.dependencySnapshotFile === '') {
-          return Promise.resolve()
-        }
-        return this._generateDependencySnapshot()
+      .then((info) => {
+        return this._maybeGenerateDependencySnapshot(info)
       })
-      .then(() => {
-        return this._dependencies()
+      .then((info) => {
+        return this._maybeGenerateDependencyComplianceReport(info)
       })
-      .then(() => {
-        return this._commitChanges()
+      .then((info) => {
+        return this._maybeUpdateBaselineCoverage(info)
       })
-      .then(() => {
-        return this._createTag()
+      .then((info) => {
+        return this._maybeCommitChanges(info)
       })
-      .then(() => {
-        return this.ci.push(this.vcs)
+      .then((info) => {
+        return this._maybeCreateTag(info)
+      })
+      .then((info) => {
+        return this._maybePushChanges(info)
       })
   }
 
@@ -148,112 +155,6 @@ class Bumper {
   }
 
   // = Private Methods ==================================================================
-
-  /**
-   * Bump the version in package.json with the given scope
-   * @param {PrInfo} info - the pr info
-   * @param {String} pkgJsonFile - the full file path to the package.json to bump
-   * @returns {PrInfo} the pr info object passed in
-   */
-  _bumpVersion (info, pkgJsonFile) {
-    const v = versiony.from(pkgJsonFile).indent(' '.repeat(2))
-    switch (info.scope) {
-      case 'patch':
-        v.patch()
-        break
-
-      case 'minor':
-        v.minor().patch(0)
-        break
-
-      case 'major':
-        v.newMajor()
-        break
-
-      case 'none':
-        return info
-
-      default:
-        throw new Error(`Invalid scope [${info.scope}]`)
-    }
-
-    const versionInfo = v.to(pkgJsonFile).end()
-    info.version = versionInfo.version
-    return info
-  }
-
-  /**
-   * Commit the changed files 'package.json' and 'CHANGELOG.md'
-   * @param {Object} config - the .pr-bumper.json config
-   * @returns {Promise} - a promise resolved with the results of the git commands
-   */
-  _commitChanges () {
-    const buildNumber = this.config.ci.buildNumber
-
-    return this.ci.setupGitEnv()
-      .then(() => {
-        // TODO: make this more configurable? (what's being bumped that is)
-        const adds = ['package.json', 'CHANGELOG.md']
-        if (this.config.dependencySnapshotFile !== '') {
-          adds.push(this.config.dependencySnapshotFile)
-        }
-        const reportOutput = __.get(this.config, 'dependencies.output.directory')
-        if (reportOutput) {
-          adds.push(`${reportOutput}/`)
-        }
-        return this.ci.add(adds)
-      })
-      .then(() => {
-        return this.ci.commit('Automated version bump', `From CI build ${buildNumber}`)
-      })
-  }
-
-  /**
-   * Create a tag based on the current version
-   * @returns {Promise} - a promise resolved with the results of the git commands
-   */
-  _createTag () {
-    const buildNumber = this.config.ci.buildNumber
-
-    return exec('node -e "console.log(require(\'./package.json\').version)"')
-      .then((stdout) => {
-        const name = stdout.replace('\n', '')
-        return this.ci.tag(`v${name}`, `Generated tag from CI build ${buildNumber}`)
-      })
-  }
-
-  /**
-   * process a dependency report
-   * @param {Object} config the .pr-bumper.json config
-   * @returns {Promise} a Promise
-   **/
-  _dependencies () {
-    const cwd = process.cwd()
-    let outputPath = __.get(this.config, 'dependencies.output.directory')
-    const absOutputPath = outputPath ? path.join(cwd, outputPath) : null
-    if (absOutputPath) {
-      return dependencies.run(cwd, absOutputPath, this.config)
-    }
-    return Promise.resolve('skipping dependencies')
-  }
-
-  /**
-   * Generate a dependency snapshot file by using `npm shrinkwrap`
-   * TODO: do we want to handle projects that include npm-shrinkwrap.json?
-   * @returns {Promise} a promise resolved when operation completes
-   */
-  _generateDependencySnapshot () {
-    // We need to do the prune b/c of the following issue with npm-shrinkwrap
-    // https://github.com/SaltwaterC/aws2js/issues/58, apparently one of our deps
-    // installs things w/o having them in package.json, causing npm shrinkwrap to barf
-    return exec('npm prune')
-      .then(() => {
-        return exec('npm shrinkwrap --dev')
-      })
-      .then(() => {
-        return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
-      })
-  }
 
   /**
    * Compute the log message to tell users whether coverage went up or stayed the same
@@ -310,6 +211,7 @@ class Bumper {
 
         return {
           changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
+          modifiedFiles: [],
           scope: scope
         }
       })
@@ -334,14 +236,224 @@ class Bumper {
   }
 
   /**
-   * Prepend the changelog text from the PrInfo into the
+   * Maybe bump the version in package.json with the given scope (if it's not "none")
    * @param {PrInfo} info - the pr info
-   * @param {String} changelogFile - the full file path to the CHANGELOG.md file to bump
+   * @param {String} pkgJsonFile - the full file path to the package.json to bump
+   * @returns {PrInfo} the pr info object passed in
+   */
+  _maybeBumpVersion (info, pkgJsonFile) {
+    if (info.scope === 'none') {
+      return info
+    }
+
+    const v = versiony.from(pkgJsonFile).indent(' '.repeat(2))
+    switch (info.scope) {
+      case 'patch':
+        v.patch()
+        break
+
+      case 'minor':
+        v.minor().patch(0)
+        break
+
+      case 'major':
+        v.newMajor()
+        break
+
+      default:
+        throw new Error(`Invalid scope [${info.scope}]`)
+    }
+
+    const versionInfo = v.to(pkgJsonFile).end()
+    info.version = versionInfo.version
+    addModifiedFile(info, pkgJsonFile)
+    return info
+  }
+
+  /**
+   * Commit the changed files that were modified by pr-bumper
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} - a promise resolved with the results of the git commands
+   */
+  _maybeCommitChanges (info) {
+    if (info.modifiedFiles.length === 0) {
+      logger.log('Skipping commit because no files were changed.')
+      return Promise.resolve(info)
+    }
+
+    const buildNumber = this.config.ci.buildNumber
+
+    return this.ci.setupGitEnv()
+      .then(() => {
+        return this.ci.add(info.modifiedFiles)
+      })
+      .then(() => {
+        // Currently there are only two reasons we'll have a commit 1) we have a "none" bump with coverage
+        // change, or 2) we have a legit bump commit
+        let msg = 'Automated version bump'
+        if (info.scope === 'none') {
+          msg = 'Automated code coverage update'
+        }
+
+        return this.ci.commit(`[${pkgJson.name}] ${msg}`, `From CI build ${buildNumber}`)
+          .then(() => {
+            return info
+          })
+      })
+  }
+
+  /**
+   * Maybe create a tag based on the current version
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} - a promise resolved with the results of the git commands
+   */
+  _maybeCreateTag (info) {
+    if (info.scope === 'none') {
+      logger.log('Skipping tag creation because of "none" scope.')
+      return Promise.resolve(info)
+    }
+
+    const buildNumber = this.config.ci.buildNumber
+    return this.ci.tag(`v${info.version}`, `Generated tag from CI build ${buildNumber}`)
+      .then(() => {
+        return info
+      })
+  }
+
+  /**
+   * process a dependency report
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} a Promise
+   */
+  _maybeGenerateDependencyComplianceReport (info) {
+    let outputPath = __.get(this.config, 'dependencies.output.directory')
+
+    if (!outputPath) {
+      logger.log('Skipping generating dependency compliance report because of config option.')
+      return Promise.resolve(info)
+    }
+
+    if (info.scope === 'none') {
+      logger.log('Skipping generating dependency compliance report because of "none" scope.')
+      return Promise.resolve(info)
+    }
+
+    const cwd = process.cwd()
+    return dependencies.run(cwd, path.join(cwd, outputPath), this.config)
+      .then(() => {
+        addModifiedFile(info, outputPath)
+        return info
+      })
+  }
+
+  /**
+   * Maybe generate a dependency snapshot file by using `npm shrinkwrap`
+   * TODO: do we want to handle projects that include npm-shrinkwrap.json?
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} a promise resolved when operation completes
+   */
+  _maybeGenerateDependencySnapshot (info) {
+    // We need to do the prune b/c of the following issue with npm-shrinkwrap
+    // https://github.com/SaltwaterC/aws2js/issues/58, apparently one of our deps
+    // installs things w/o having them in package.json, causing npm shrinkwrap to barf
+
+    if (!this.config.dependencySnapshotFile) {
+      logger.log('Skipping generating dependency snapshot because of config option.')
+      return Promise.resolve(info)
+    }
+
+    if (info.scope === 'none') {
+      logger.log('Skipping generating dependency snapshot because of "none" scope.')
+      return Promise.resolve(info)
+    }
+
+    return exec('npm prune')
+      .then(() => {
+        return exec('npm shrinkwrap --dev')
+      })
+      .then(() => {
+        return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
+      })
+      .then(() => {
+        addModifiedFile(info, this.config.dependencySnapshotFile)
+        return info
+      })
+  }
+
+  /**
+   * Maybe prepend the changelog text from the PrInfo into the CHANGELOG.md file (unless there was no bump)
+   * @param {PrInfo} info - the pr info
    * @returns {Promise} - a promise resolved when changelog has been prepended
    */
-  _prependChangelog (info, changelogFile) {
+  _maybePrependChangelog (info) {
+    if (!this.config.prependChangelog) {
+      logger.log('Skipping prepending changelog because of config option.')
+      return Promise.resolve(info)
+    }
+
+    if (info.scope === 'none') {
+      logger.log('Skipping prepending changelog because of "none" scope.')
+      return Promise.resolve(info)
+    }
+
     const data = `# ${info.version}\n${info.changelog}\n\n`
-    return prepend(changelogFile, data)
+    return prepend(this.config.changelogFile, data)
+      .then(() => {
+        addModifiedFile(info, this.config.changelogFile)
+        return info
+      })
+  }
+
+  /**
+   * Maybe push changes back to repo
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} - a promise resolved with the results of the git commands
+   */
+  _maybePushChanges (info) {
+    if (info.modifiedFiles.length === 0) {
+      logger.log('Skipping push because nothing changed.')
+      return Promise.resolve(info)
+    }
+
+    return this.ci.push(this.vcs)
+      .then(() => {
+        return info
+      })
+  }
+
+  /**
+   * Maybe update the code coverage in package.json
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @param {Object} _pkgJson - the contents of `package.json` for the project being bumped (used for testing)
+   * @returns {Promise} a Promise
+   **/
+  _maybeUpdateBaselineCoverage (info, _pkgJson) {
+    const base = this.config.baselineCoverage
+    if (!__.isNumber(base)) {
+      logger.log('Skipping updating baseline code coverage because no valid coverage found.')
+      return Promise.resolve(info)
+    }
+
+    const link = 'https://github.com/ciena-blueplanet/pr-bumper#code-coverage'
+    const pct = utils.getCurrentCoverage()
+    if (pct < 0) {
+      const msg = `No current coverage info found!\nSee ${link} for configuration info.`
+      return Promise.reject(msg)
+    }
+
+    let pkgJsonContents = _pkgJson
+    const pkgJsonPath = path.join(process.cwd(), 'package.json')
+    if (!pkgJsonContents) {
+      pkgJsonContents = require(pkgJsonPath)
+    }
+
+    pkgJsonContents['pr-bumper'].coverage = pct
+
+    return writeFile(pkgJsonPath, JSON.stringify(pkgJsonContents, null, 2))
+      .then(() => {
+        addModifiedFile(info, 'package.json')
+        return info
+      })
   }
 }
 

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -16,7 +16,6 @@ let dependencies = require('./compliance/dependencies')
 let exec = Promise.denodeify(cpExec)
 let prepend = Promise.denodeify(prependFile)
 
-const pkgJson = require('../package.json')
 const logger = require('./logger')
 const utils = require('./utils')
 
@@ -52,7 +51,7 @@ class Bumper {
    */
   bump () {
     if (this.config.isPr) {
-      logger.log(`${pkgJson.name}: Not a merge build, skipping bump`)
+      logger.log('Not a merge build, skipping bump')
       return Promise.resolve()
     }
 
@@ -107,7 +106,7 @@ class Bumper {
    */
   check () {
     if (!this.config.isPr) {
-      logger.log(`${pkgJson.name}: Not a PR build, skipping check`)
+      logger.log('Not a PR build, skipping check')
       return Promise.resolve()
     }
 
@@ -115,6 +114,37 @@ class Bumper {
       .then((info) => {
         logger.log(`Found a ${info.scope} bump for the current PR`)
       })
+  }
+
+  /**
+   * Check a build to see if coverage decreased
+   * @returns {Promise} a promise resolved when complete or rejected on error
+   */
+  checkCoverage () {
+    const link = 'https://github.com/ciena-blueplanet/pr-bumper#code-coverage'
+    const base = this.config.baselineCoverage
+    if (!__.isNumber(base)) {
+      const msg = `No baseline coverage info found!\nSee ${link} for configuration info.`
+      return Promise.reject(msg)
+    }
+
+    const pct = utils.getCurrentCoverage()
+    if (pct < 0) {
+      const msg = `No current coverage info found!\nSee ${link} for configuration info.`
+      return Promise.reject(msg)
+    }
+
+    if (base > pct) {
+      const diffStr = (base - pct).toFixed(2)
+      const baseStr = base.toFixed(2)
+      const pctStr = pct.toFixed(2)
+      const msg = `Coverage dropped ${diffStr}% (from ${baseStr}% to ${pctStr}%) in this PR!`
+      return Promise.reject(msg)
+    }
+
+    const msg = this._getCoverageMsg(base, pct)
+    logger.log(msg)
+    return Promise.resolve()
   }
 
   // = Private Methods ==================================================================
@@ -144,7 +174,7 @@ class Bumper {
         return info
 
       default:
-        throw new Error(`pr-bumper: Invalid scope [${info.scope}]`)
+        throw new Error(`Invalid scope [${info.scope}]`)
     }
 
     const versionInfo = v.to(pkgJsonFile).end()
@@ -223,6 +253,23 @@ class Bumper {
       .then(() => {
         return exec(`mv npm-shrinkwrap.json ${this.config.dependencySnapshotFile}`)
       })
+  }
+
+  /**
+   * Compute the log message to tell users whether coverage went up or stayed the same
+   * @param {Number} base - the base coverage percentage
+   * @param {Number} pct - the current coverage percentage
+   * @returns {String} the message to log to the user explaining what happened with coverage
+   */
+  _getCoverageMsg (base, pct) {
+    const pctStr = pct.toFixed(2)
+    const baseStr = base.toFixed(2)
+    if (pct > base) {
+      const diffStr = (pct - base).toFixed(2)
+      return `Coverage increased ${diffStr}% (from ${baseStr}% to ${pctStr}%) in this PR! Good job :)`
+    } else {
+      return `Coverage remained the same (at ${baseStr}%) in this PR.`
+    }
   }
 
   /**

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -30,7 +30,7 @@ const utils = require('./utils')
  * @param {String} filename - the filename to add to info.modifiedFiles if it's not already there
  */
 function addModifiedFile (info, filename) {
-  if (!info.modifiedFiles.includes(filename)) {
+  if (info.modifiedFiles.indexOf(filename) === -1) {
     info.modifiedFiles.push(filename)
   }
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,6 +35,8 @@ class Cli {
       return bumper.bump()
     } else if (cmd === 'check') {
       return bumper.check()
+    } else if (cmd === 'check-coverage') {
+      return bumper.checkCoverage()
     }
 
     return Promise.reject(`Invalid command: ${cmd}`)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const pkgJson = require('../package.json')
+
 const logger = {
   /**
    * Simple wrapper around console.log() to make it easy to mock it out in tests
@@ -7,7 +9,7 @@ const logger = {
    */
   log (msg) {
     // TODO: check a VERBOSE env var
-    console.log(msg)
+    console.log(`${pkgJson.name}: ${msg}`)
   },
 
   /**
@@ -16,7 +18,7 @@ const logger = {
    */
   error (msg) {
     // TODO: ignore a VERBOSE env var
-    console.error(msg)
+    console.error(`${pkgJson.name}: ${msg}`)
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,6 +145,7 @@ const utils = {
         },
         additionalRepos: []
       },
+      changelogFile: 'CHANGELOG.md',
       dependencySnapshotFile: 'dependency-snapshot.json',
       vcs: {
         domain: 'github.com',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,9 +105,10 @@ const utils = {
   /**
    * Read in the config from a file and apply defaults
    * @param {Config} [_config] - the configuration for the pr-bumper
+   * @param {Object} [_pkgJson] - the data from package.json (passed in during testing)
    * @returns {Config} the config object
    */
-  getConfig (_config) {
+  getConfig (_config, _pkgJson) {
     let config = _config || {}
 
     try {
@@ -165,6 +166,16 @@ const utils = {
     })
 
     processEnv(config)
+
+    let pkgJson = _pkgJson
+
+    if (!pkgJson) {
+      pkgJson = require(path.join(process.cwd(), 'package.json'))
+    }
+
+    if (pkgJson && pkgJson['pr-bumper'] && pkgJson['pr-bumper'].coverage) {
+      config.baselineCoverage = pkgJson['pr-bumper'].coverage
+    }
 
     return config
   },
@@ -256,6 +267,22 @@ const utils = {
     }
 
     return changelog
+  },
+
+  /**
+   * Get the current coverage stats from istanbul coverage-summary data
+   * @param {Object} _coverageSummary - contents of coverage-summary.json file (used for testing)
+   * @returns {Number} the coverage line percentage
+   */
+  getCurrentCoverage (_coverageSummary) {
+    let coverageSummary = _coverageSummary
+    if (!coverageSummary) {
+      coverageSummary = require(path.join(process.cwd(), 'coverage/coverage-summary.json'))
+    }
+
+    const pct = __.get(coverageSummary, 'total.lines.pct') || -1
+
+    return pct
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint *.js bin lib tests",
     "test": "npm run-script lint && npm run-script utest",
-    "utest": "istanbul cover _mocha tests tests/ci tests/vcs tests/compliance"
+    "utest": "istanbul cover _mocha tests tests/ci tests/vcs tests/compliance --report lcov --report json-summary"
   },
   "bin": {
     "pr-bumper": "./bin/cli.js"
@@ -54,5 +54,8 @@
     "rewire": "^2.5.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
+  },
+  "pr-bumper": {
+    "coverage": 91.24
   }
 }

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -11,32 +11,32 @@ const sinonChai = require('sinon-chai')
 const expect = chai.expect
 chai.use(sinonChai)
 
+const pkgJson = require('../package.json')
 const utils = require('../lib/utils')
 const logger = require('../lib/logger')
 const Bumper = rewire('../lib/bumper')
 
 const exec = Promise.denodeify(cpExec)
 const getVersionCmd = 'node -e "console.log(require(\'./_package.json\').version)"'
-const realGetVersionCmd = 'node -e "console.log(require(\'./package.json\').version)"'
 
 /**
- * Helper for performing repetative tasks in setting up _bumpVersion tests
+ * Helper for performing repetative tasks in setting up _maybeBumpVersion tests
  * Since versiony doesn't let you tell it to be quiet, we need to stub out
- * console.log() but only while _bumpVersion runs, or we won't get mocha output
+ * console.log() but only while _maybeBumpVersion runs, or we won't get mocha output
  * while running our tests
  *
  * @param {Object} ctx - the context object so the function can pass some info back to the tests for validation
  * @param {String} scope - the scope to bump
  * @param {String} expectedVersion - the expected version after the bump
  */
-function testBumpVersion (ctx, scope, expectedVersion) {
+function testMaybeBumpVersion (ctx, scope, expectedVersion) {
   describe(`a ${scope}`, function () {
     let bumper, logStub, info, newVersion
     beforeEach(function () {
       bumper = ctx.bumper
 
       logStub = sinon.stub(console, 'log')
-      info = bumper._bumpVersion({scope}, '_package.json')
+      info = bumper._maybeBumpVersion({scope, modifiedFiles: []}, '_package.json')
       logStub.restore()
 
       return exec(`${getVersionCmd}`)
@@ -53,16 +53,28 @@ function testBumpVersion (ctx, scope, expectedVersion) {
       it('should not include the version', function () {
         expect(info.version).to.equal(undefined)
       })
+
+      it('should not add "package.json" to the list of modified files', function () {
+        expect(info.modifiedFiles).not.to.include('_package.json')
+      })
     } else {
       it('should return the correct version', function () {
         expect(info.version).to.be.equal(expectedVersion)
+      })
+
+      it('should add "package.json" to the list of modified files', function () {
+        expect(info.modifiedFiles).to.include('_package.json')
       })
     }
   })
 }
 
 describe('Bumper', function () {
-  let bumper, sandbox, execStub, revertExecRewire, prependStub, revertPrepend, depStub, revertDeps
+  let bumper, sandbox
+  let execStub, revertExecRewire
+  let prependStub, revertPrepend
+  let depStub, revertDeps
+  let writeFileStub, revertWriteFileRewire
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
@@ -82,6 +94,10 @@ describe('Bumper', function () {
     }
     revertDeps = Bumper.__set__('dependencies', depStub)
 
+    // stub out the top-level 'writeFile'
+    writeFileStub = sandbox.stub()
+    revertWriteFileRewire = Bumper.__set__('writeFile', writeFileStub)
+
     bumper = new Bumper({
       ci: [],
       config: {},
@@ -94,6 +110,7 @@ describe('Bumper', function () {
     revertExecRewire()
     revertPrepend()
     revertDeps()
+    revertWriteFileRewire()
   })
 
   describe('.check()', function () {
@@ -324,15 +341,16 @@ describe('Bumper', function () {
       bumper.vcs = {foo: 'bar'}
       bumper.ci = {push () {}, getLastCommitMsg () {}}
       info = {scope: 'minor', changelog: '', version: '1.2.0'}
-      sandbox.stub(bumper.ci, 'push').returns(Promise.resolve('pushed'))
+      sandbox.stub(bumper, '_maybePushChanges').returns(Promise.resolve('pushed'))
       sandbox.stub(bumper.ci, 'getLastCommitMsg')
       sandbox.stub(bumper, '_getMergedPrInfo').returns(Promise.resolve(info))
-      sandbox.stub(bumper, '_bumpVersion').returns(Promise.resolve(info))
-      sandbox.stub(bumper, '_prependChangelog').returns(Promise.resolve())
-      sandbox.stub(bumper, '_generateDependencySnapshot').returns(Promise.resolve())
-      sandbox.stub(bumper, '_commitChanges').returns(Promise.resolve())
-      sandbox.stub(bumper, '_createTag').returns(Promise.resolve())
-      sandbox.stub(bumper, '_dependencies').returns(Promise.resolve())
+      sandbox.stub(bumper, '_maybeBumpVersion').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybePrependChangelog').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybeGenerateDependencySnapshot').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybeCommitChanges').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybeCreateTag').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybeUpdateBaselineCoverage').returns(Promise.resolve(info))
+      sandbox.stub(bumper, '_maybeGenerateDependencyComplianceReport').returns(Promise.resolve(info))
     })
 
     describe('when a merge build', function () {
@@ -354,90 +372,36 @@ describe('Bumper', function () {
         expect(bumper._getMergedPrInfo).to.have.callCount(1)
       })
 
-      it('should bump the version', function () {
-        expect(bumper._bumpVersion).to.have.been.calledWith(info, 'package.json')
+      it('should maybe bump the version', function () {
+        expect(bumper._maybeBumpVersion).to.have.been.calledWith(info, 'package.json')
       })
 
-      it('should prepend the changelog', function () {
-        expect(bumper._prependChangelog).to.have.been.calledWith(info, 'CHANGELOG.md')
+      it('should maybe prepend the changelog', function () {
+        expect(bumper._maybePrependChangelog).to.have.been.calledWith(info)
       })
 
-      it('should generate the dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(1)
+      it('should maybe generate the dependency snapshot', function () {
+        expect(bumper._maybeGenerateDependencySnapshot).to.have.been.calledWith(info)
       })
 
-      it('should commit the change', function () {
-        expect(bumper._commitChanges).to.have.callCount(1)
+      it('should maybe update baseline coverage', function () {
+        expect(bumper._maybeUpdateBaselineCoverage).to.have.been.calledWith(info)
       })
 
-      it('should create the tag', function () {
-        expect(bumper._createTag).to.have.callCount(1)
+      it('should maybe commit the change', function () {
+        expect(bumper._maybeCommitChanges).to.have.been.calledWith(info)
       })
 
-      it('should run the dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(1)
+      it('should maybe create the tag', function () {
+        expect(bumper._maybeCreateTag).to.have.been.calledWith(info)
       })
 
-      it('should push the changes', function () {
-        expect(bumper.ci.push).to.have.been.calledWith(bumper.vcs)
+      it('should maybe run the dependencies', function () {
+        expect(bumper._maybeGenerateDependencyComplianceReport).to.have.been.calledWith(info)
       })
 
-      it('should resolve with the result of the ci.push()', function () {
-        expect(result).to.be.eql('pushed')
-      })
-
-      it('should not reject', function () {
-        expect(error).to.equal(null)
-      })
-    })
-
-    describe('when prependChangelog is false', function () {
-      beforeEach(function (done) {
-        bumper.ci.getLastCommitMsg.returns(Promise.resolve('foo bar'))
-        bumper.config.prependChangelog = false
-
-        bumper.bump()
-          .then((res) => {
-            result = res
-          })
-          .catch((err) => {
-            error = err
-          })
-          .finally(() => {
-            done()
-          })
-      })
-
-      it('should get the merged pr info', function () {
-        expect(bumper._getMergedPrInfo).to.have.callCount(1)
-      })
-
-      it('should bump the version', function () {
-        expect(bumper._bumpVersion).to.have.been.calledWith(info, 'package.json')
-      })
-
-      it('should not prepend the changelog', function () {
-        expect(bumper._prependChangelog).to.have.callCount(0)
-      })
-
-      it('should generate the dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(1)
-      })
-
-      it('should commit the change', function () {
-        expect(bumper._commitChanges).to.have.callCount(1)
-      })
-
-      it('should create the tag', function () {
-        expect(bumper._createTag).to.have.callCount(1)
-      })
-
-      it('should run the dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(1)
-      })
-
-      it('should push the changes', function () {
-        expect(bumper.ci.push).to.have.been.calledWith(bumper.vcs)
+      it('should maybe push the changes', function () {
+        expect(bumper._maybePushChanges).to.have.been.calledWith(info)
       })
 
       it('should resolve with the result of the ci.push()', function () {
@@ -449,67 +413,9 @@ describe('Bumper', function () {
       })
     })
 
-    describe('when dependencySnapshotFile is blank', function () {
+    describe(`when last commit was from ${pkgJson.name}`, function () {
       beforeEach(function (done) {
-        bumper.ci.getLastCommitMsg.returns(Promise.resolve('foo bar'))
-        bumper.config.dependencySnapshotFile = ''
-
-        bumper.bump()
-          .then((res) => {
-            result = res
-          })
-          .catch((err) => {
-            error = err
-          })
-          .finally(() => {
-            done()
-          })
-      })
-
-      it('should get the merged pr info', function () {
-        expect(bumper._getMergedPrInfo).to.have.callCount(1)
-      })
-
-      it('should bump the version', function () {
-        expect(bumper._bumpVersion).to.have.been.calledWith(info, 'package.json')
-      })
-
-      it('should prepend the changelog', function () {
-        expect(bumper._prependChangelog).to.have.been.calledWith(info, 'CHANGELOG.md')
-      })
-
-      it('should not generate the dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(0)
-      })
-
-      it('should commit the change', function () {
-        expect(bumper._commitChanges).to.have.callCount(1)
-      })
-
-      it('should create the tag', function () {
-        expect(bumper._createTag).to.have.callCount(1)
-      })
-
-      it('should run the dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(1)
-      })
-
-      it('should push the changes', function () {
-        expect(bumper.ci.push).to.have.been.calledWith(bumper.vcs)
-      })
-
-      it('should resolve with the result of the ci.push()', function () {
-        expect(result).to.be.eql('pushed')
-      })
-
-      it('should not reject', function () {
-        expect(error).to.equal(null)
-      })
-    })
-
-    describe('when last commit was automated version bump', function () {
-      beforeEach(function (done) {
-        bumper.ci.getLastCommitMsg.returns(Promise.resolve('Automated version bump'))
+        bumper.ci.getLastCommitMsg.returns(Promise.resolve(`[${pkgJson.name}] Fizz bang`))
         bumper.bump()
           .then((res) => {
             result = res
@@ -526,93 +432,36 @@ describe('Bumper', function () {
         expect(bumper._getMergedPrInfo).to.have.callCount(0)
       })
 
-      it('should not bump version', function () {
-        expect(bumper._bumpVersion).to.have.callCount(0)
+      it('should not maybe bump version', function () {
+        expect(bumper._maybeBumpVersion).to.have.callCount(0)
       })
 
-      it('should not prepend changelog', function () {
-        expect(bumper._prependChangelog).to.have.callCount(0)
+      it('should not maybe prepend changelog', function () {
+        expect(bumper._maybePrependChangelog).to.have.callCount(0)
       })
 
-      it('should not generate a dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(0)
+      it('should not maybe generate a dependency snapshot', function () {
+        expect(bumper._maybeGenerateDependencySnapshot).to.have.callCount(0)
       })
 
-      it('should not calcualte dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(0)
+      it('should not maybe calcualte dependencies', function () {
+        expect(bumper._maybeGenerateDependencyComplianceReport).to.have.callCount(0)
       })
 
-      it('should not commit changes', function () {
-        expect(bumper._commitChanges).to.have.callCount(0)
+      it('should not maybe update baseline coverage', function () {
+        expect(bumper._maybeUpdateBaselineCoverage).to.have.callCount(0)
       })
 
-      it('should not create a tag', function () {
-        expect(bumper._createTag).to.have.callCount(0)
+      it('should not maybe commit changes', function () {
+        expect(bumper._maybeCommitChanges).to.have.callCount(0)
       })
 
-      it('should not push commit', function () {
-        expect(bumper.ci.push).to.have.callCount(0)
+      it('should not maybe create a tag', function () {
+        expect(bumper._maybeCreateTag).to.have.callCount(0)
       })
 
-      it('should not resolve', function () {
-        expect(result).to.equal(null)
-      })
-
-      it('should reject with a Cancel', function () {
-        expect(error).to.be.instanceof(Bumper.Cancel)
-      })
-
-      it('should reject with proper message', function () {
-        expect(error.message).to.equal('Skipping bump on version bump commit.')
-      })
-    })
-
-    describe('when no version bump happens', function () {
-      beforeEach(function (done) {
-        bumper.ci.getLastCommitMsg.returns(Promise.resolve('fizz bang'))
-        bumper._bumpVersion.returns(Promise.resolve({scope: 'none', changelog: ''}))
-        bumper.bump()
-          .then((res) => {
-            result = res
-          })
-          .catch((err) => {
-            error = err
-          })
-          .finally(() => {
-            done()
-          })
-      })
-
-      it('should lookup merged PR info', function () {
-        expect(bumper._getMergedPrInfo).to.have.callCount(1)
-      })
-
-      it('should call _bumpVersion()', function () {
-        expect(bumper._bumpVersion).to.have.callCount(1)
-      })
-
-      it('should not prepend changelog', function () {
-        expect(bumper._prependChangelog).to.have.callCount(0)
-      })
-
-      it('should not generate a dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(0)
-      })
-
-      it('should not calcualte dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(0)
-      })
-
-      it('should not commit changes', function () {
-        expect(bumper._commitChanges).to.have.callCount(0)
-      })
-
-      it('should not create a tag', function () {
-        expect(bumper._createTag).to.have.callCount(0)
-      })
-
-      it('should not push commit', function () {
-        expect(bumper.ci.push).to.have.callCount(0)
+      it('should not maybe push commit', function () {
+        expect(bumper._maybePushChanges).to.have.callCount(0)
       })
 
       it('should not resolve', function () {
@@ -624,7 +473,7 @@ describe('Bumper', function () {
       })
 
       it('should reject with proper message', function () {
-        expect(error.message).to.equal('Skipping bump commit since version did not change.')
+        expect(error.message).to.equal(`Skipping bump on ${pkgJson.name} commit.`)
       })
     })
 
@@ -652,245 +501,41 @@ describe('Bumper', function () {
         expect(bumper._getMergedPrInfo).to.have.callCount(0)
       })
 
-      it('should not bump version', function () {
-        expect(bumper._bumpVersion).to.have.callCount(0)
+      it('should not maybe bump version', function () {
+        expect(bumper._maybeBumpVersion).to.have.callCount(0)
       })
 
-      it('should not prepend changelog', function () {
-        expect(bumper._prependChangelog).to.have.callCount(0)
+      it('should not maybe prepend changelog', function () {
+        expect(bumper._maybePrependChangelog).to.have.callCount(0)
       })
 
-      it('should not generate a dependency snapshot', function () {
-        expect(bumper._generateDependencySnapshot).to.have.callCount(0)
+      it('should not maybe generate a dependency snapshot', function () {
+        expect(bumper._maybeGenerateDependencySnapshot).to.have.callCount(0)
       })
 
-      it('should not calcualte dependencies', function () {
-        expect(bumper._dependencies).to.have.callCount(0)
+      it('should not maybe calcualte dependencies', function () {
+        expect(bumper._maybeGenerateDependencyComplianceReport).to.have.callCount(0)
       })
 
-      it('should not commit changes', function () {
-        expect(bumper._commitChanges).to.have.callCount(0)
+      it('should not maybe update baseline coverage', function () {
+        expect(bumper._maybeUpdateBaselineCoverage).to.have.callCount(0)
       })
 
-      it('should not create a tag', function () {
-        expect(bumper._createTag).to.have.callCount(0)
+      it('should not maybe commit changes', function () {
+        expect(bumper._maybeCommitChanges).to.have.callCount(0)
       })
 
-      it('should not push commit', function () {
-        expect(bumper.ci.push).to.have.callCount(0)
+      it('should not maybe create a tag', function () {
+        expect(bumper._maybeCreateTag).to.have.callCount(0)
+      })
+
+      it('should not maybe push commit', function () {
+        expect(bumper._maybePushChanges).to.have.callCount(0)
       })
 
       it('should not reject', function () {
         expect(error).to.equal(null)
       })
-    })
-  })
-
-  describe('._bumpVersion()', function () {
-    const ctx = {}
-
-    beforeEach(function () {
-      ctx.bumper = bumper
-
-      let original = path.join(__dirname, '_package.json')
-      return exec(`cp ${original} _package.json`)
-    })
-
-    afterEach(function () {
-      return exec('rm -f _package.json')
-    })
-
-    testBumpVersion(ctx, 'none', '1.2.3')
-    testBumpVersion(ctx, 'patch', '1.2.4')
-    testBumpVersion(ctx, 'minor', '1.3.0')
-    testBumpVersion(ctx, 'major', '2.0.0')
-
-    describe('an invalid scope', function () {
-      let info
-      beforeEach(function () {
-        info = {scope: 'foo'}
-      })
-
-      it('should throw an Error', function () {
-        expect(() => {
-          bumper._bumpVersion(info, '_package.json')
-        }).to.throw('Invalid scope [foo]')
-      })
-    })
-  })
-
-  describe('._commitChanges()', function () {
-    let result
-
-    beforeEach(function () {
-      __.set(bumper.config, 'ci.buildNumber', '12345')
-      __.set(bumper.config, 'dependencies.output.directory', 'some-dir')
-
-      bumper.ci = {
-        add () {},
-        commit () {},
-        setupGitEnv () {}
-      }
-
-      sandbox.stub(bumper.ci, 'add').returns(Promise.resolve('added'))
-      sandbox.stub(bumper.ci, 'commit').returns(Promise.resolve('committed'))
-      sandbox.stub(bumper.ci, 'setupGitEnv').returns(Promise.resolve('set-up'))
-    })
-
-    describe('when dependencySnapshotFile is set', function () {
-      beforeEach(function () {
-        bumper.config.dependencySnapshotFile = 'snapshot-file'
-
-        return bumper._commitChanges().then((res) => {
-          result = res
-        })
-      })
-
-      it('should set up git env', function () {
-        expect(bumper.ci.setupGitEnv).to.have.callCount(1)
-      })
-
-      it('should add the files to stage', function () {
-        expect(bumper.ci.add).to.have.been.calledWith(['package.json', 'CHANGELOG.md', 'snapshot-file', 'some-dir/'])
-      })
-
-      it('should commits the changes', function () {
-        const summary = 'Automated version bump'
-        const message = 'From CI build 12345'
-
-        expect(bumper.ci.commit).to.have.been.calledWith(summary, message)
-      })
-
-      it('should resolve with the result of the commit', function () {
-        expect(result).to.be.equal('committed')
-      })
-    })
-
-    describe('when dependencySnapshotFile is not set', function () {
-      beforeEach(function () {
-        bumper.config.dependencySnapshotFile = ''
-
-        return bumper._commitChanges().then((res) => {
-          result = res
-        })
-      })
-
-      it('should set up git env', function () {
-        expect(bumper.ci.setupGitEnv).to.have.callCount(1)
-      })
-
-      it('should add the files to stage', function () {
-        expect(bumper.ci.add).to.have.been.calledWith(['package.json', 'CHANGELOG.md', 'some-dir/'])
-      })
-
-      it('should commits the changes', function () {
-        const summary = 'Automated version bump'
-        const message = 'From CI build 12345'
-
-        expect(bumper.ci.commit).to.have.been.calledWith(summary, message)
-      })
-
-      it('should resolve with the result of the commit', function () {
-        expect(result).to.be.equal('committed')
-      })
-    })
-  })
-
-  describe('._createTag()', function () {
-    let result
-
-    beforeEach(function () {
-      __.set(bumper.config, 'ci.buildNumber', '12345')
-      bumper.ci = {
-        tag () {}
-      }
-
-      sandbox.stub(bumper.ci, 'tag').returns(Promise.resolve('tagged'))
-
-      // we want exec() to return a simple resolved Promise most of the time, but when it gets the node call
-      // it needs to return a version number
-      execStub.withArgs(realGetVersionCmd).returns(Promise.resolve('1.2.3\n'))
-      execStub.returns(Promise.resolve())
-
-      return bumper._createTag().then((res) => {
-        result = res
-      })
-    })
-
-    it('should get the version', function () {
-      expect(execStub).to.have.been.calledWith(realGetVersionCmd)
-    })
-
-    it('should create a tag', function () {
-      expect(bumper.ci.tag).to.have.been.calledWith('v1.2.3', 'Generated tag from CI build 12345')
-    })
-
-    it('should resolve with the result of the tag', function () {
-      expect(result).to.be.equal('tagged')
-    })
-  })
-
-  describe('._dependencies()', function () {
-    let result
-    describe('when an out dir is configured', function () {
-      beforeEach(function () {
-        __.set(bumper.config, 'dependencies.output', {
-          directory: 'blackduck/',
-          requirementsFile: 'js-requirements.json',
-          reposFile: 'repos',
-          ignoreFile: 'ignore'
-        })
-
-        return bumper._dependencies().then((r) => {
-          result = r
-        })
-      })
-
-      it('should return a promise resolving to nothing', function () {
-        expect(result).to.equal(undefined)
-      })
-    })
-
-    describe('when no dir is configured', function () {
-      beforeEach(function () {
-        return bumper._dependencies((r) => {
-          result = r
-        })
-      })
-
-      it('should return a promise resolving to nothing', function () {
-        expect(result).to.equal(undefined)
-      })
-    })
-  })
-
-  describe('._generateDependencySnapshot()', function () {
-    let ret
-    beforeEach(function () {
-      bumper.config.dependencySnapshotFile = 'snapshot-file'
-      execStub.withArgs('npm prune').returns(Promise.resolve('prune-done'))
-      execStub.withArgs('npm shrinkwrap --dev').returns(Promise.resolve('shrinkwrap-done'))
-      execStub.returns(Promise.resolve('move-done'))
-
-      return bumper._generateDependencySnapshot().then((resp) => {
-        ret = resp
-      })
-    })
-
-    it('should prune node_modules so shrinkwrap will work', function () {
-      expect(execStub).to.have.been.calledWith('npm prune')
-    })
-
-    it('should generate the dependency snapshot', function () {
-      expect(execStub).to.have.been.calledWith('npm shrinkwrap --dev')
-    })
-
-    it('should rename the dependency snapshot', function () {
-      expect(execStub).to.have.been.calledWith('mv npm-shrinkwrap.json snapshot-file')
-    })
-
-    it('should return the response from the second exec', function () {
-      expect(ret).to.equal('move-done')
     })
   })
 
@@ -1005,7 +650,7 @@ describe('Bumper', function () {
           })
 
           it('should resolve with the info', function () {
-            expect(result).to.be.eql({changelog: 'my-changelog', scope})
+            expect(result).to.be.eql({changelog: 'my-changelog', modifiedFiles: [], scope})
           })
         })
 
@@ -1030,7 +675,7 @@ describe('Bumper', function () {
           })
 
           it('should resolve with the info', function () {
-            expect(result).to.be.eql({changelog: '', scope})
+            expect(result).to.be.eql({changelog: '', modifiedFiles: [], scope})
           })
         })
       })
@@ -1069,7 +714,7 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.be.eql({changelog: '', scope: 'none'})
+          expect(result).to.be.eql({changelog: '', modifiedFiles: [], scope: 'none'})
         })
       })
 
@@ -1094,7 +739,7 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.be.eql({changelog: '', scope: 'none'})
+          expect(result).to.be.eql({changelog: '', modifiedFiles: [], scope: 'none'})
         })
       })
     })
@@ -1168,26 +813,738 @@ describe('Bumper', function () {
     })
   })
 
-  describe('._prependChangelog()', function () {
-    let ret, info
+  describe('._maybeBumpVersion()', function () {
+    const ctx = {}
+
+    beforeEach(function () {
+      ctx.bumper = bumper
+
+      let original = path.join(__dirname, '_package.json')
+      return exec(`cp ${original} _package.json`)
+    })
+
+    afterEach(function () {
+      return exec('rm -f _package.json')
+    })
+
+    testMaybeBumpVersion(ctx, 'none', '1.2.3')
+    testMaybeBumpVersion(ctx, 'patch', '1.2.4')
+    testMaybeBumpVersion(ctx, 'minor', '1.3.0')
+    testMaybeBumpVersion(ctx, 'major', '2.0.0')
+
+    describe('an invalid scope', function () {
+      let info
+      beforeEach(function () {
+        info = {scope: 'foo'}
+      })
+
+      it('should throw an Error', function () {
+        expect(() => {
+          bumper._maybeBumpVersion(info, '_package.json')
+        }).to.throw('Invalid scope [foo]')
+      })
+    })
+  })
+
+  describe('._maybeCommitChanges()', function () {
+    let info, result, error
+
     beforeEach(function () {
       info = {
-        changelog: 'the-changelog-content',
-        version: '1.2.3'
+        changelog: 'stuff changed',
+        modifiedFiles: [],
+        scope: 'patch'
       }
-      prependStub.returns(Promise.resolve('return-value'))
+      __.set(bumper.config, 'ci.buildNumber', '12345')
 
-      return bumper._prependChangelog(info, 'change-log-file').then((resp) => {
-        ret = resp
+      bumper.ci = {
+        add () {},
+        commit () {},
+        setupGitEnv () {}
+      }
+
+      sandbox.stub(bumper.ci, 'add').returns(Promise.resolve())
+      sandbox.stub(bumper.ci, 'commit').returns(Promise.resolve())
+      sandbox.stub(bumper.ci, 'setupGitEnv').returns(Promise.resolve())
+    })
+
+    describe('when no files were modified', function () {
+      beforeEach(function (done) {
+        result = error = null
+        bumper._maybeCommitChanges(info)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should log info about skipping', function () {
+        expect(logger.log).to.have.been.calledWith('Skipping commit because no files were changed.')
+      })
+
+      it('should not set up the git env', function () {
+        expect(bumper.ci.setupGitEnv).to.have.callCount(0)
+      })
+
+      it('should not add any files', function () {
+        expect(bumper.ci.add).to.have.callCount(0)
+      })
+
+      it('should not commit any files', function () {
+        expect(bumper.ci.commit).to.have.callCount(0)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
       })
     })
 
-    it('should prepend the changelog', function () {
-      expect(prependStub).to.have.been.calledWith('change-log-file', '# 1.2.3\nthe-changelog-content\n\n')
+    describe('when files were modified', function () {
+      beforeEach(function (done) {
+        info.modifiedFiles = [
+          'fizz',
+          'bang'
+        ]
+        result = error = null
+        bumper._maybeCommitChanges(info)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should not log info about skipping', function () {
+        expect(logger.log).to.have.callCount(0)
+      })
+
+      it('should set up the git env', function () {
+        expect(bumper.ci.setupGitEnv).to.have.callCount(1)
+      })
+
+      it('should add the rightfiles', function () {
+        expect(bumper.ci.add).to.have.been.calledWith(['fizz', 'bang'])
+      })
+
+      it('should commit with version bump message', function () {
+        const msg = `[${pkgJson.name}] Automated version bump`
+        const descr = 'From CI build 12345'
+        expect(bumper.ci.commit).to.have.been.calledWith(msg, descr)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
     })
 
-    it('should return the response from the prepend', function () {
-      expect(ret).to.equal('return-value')
+    describe('when files were modified, and none scope', function () {
+      beforeEach(function (done) {
+        info.scope = 'none'
+        info.modifiedFiles = [
+          'fizz',
+          'bang'
+        ]
+        result = error = null
+        bumper._maybeCommitChanges(info)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should not log info about skipping', function () {
+        expect(logger.log).to.have.callCount(0)
+      })
+
+      it('should set up the git env', function () {
+        expect(bumper.ci.setupGitEnv).to.have.callCount(1)
+      })
+
+      it('should add the rightfiles', function () {
+        expect(bumper.ci.add).to.have.been.calledWith(['fizz', 'bang'])
+      })
+
+      it('should commit with coverage message', function () {
+        const msg = `[${pkgJson.name}] Automated code coverage update`
+        const descr = 'From CI build 12345'
+        expect(bumper.ci.commit).to.have.been.calledWith(msg, descr)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+  })
+
+  describe('._maybeCreateTag()', function () {
+    let result, info
+
+    beforeEach(function () {
+      info = {
+        version: '1.2.3'
+      }
+      __.set(bumper.config, 'ci.buildNumber', '12345')
+      bumper.ci = {
+        tag () {}
+      }
+
+      sandbox.stub(bumper.ci, 'tag').returns(Promise.resolve('tagged'))
+      execStub.returns(Promise.resolve())
+    })
+
+    describe('when scope is not "none"', function () {
+      beforeEach(function () {
+        return bumper._maybeCreateTag(info)
+          .then((res) => {
+            result = res
+          })
+      })
+
+      it('should create a tag', function () {
+        expect(bumper.ci.tag).to.have.been.calledWith('v1.2.3', 'Generated tag from CI build 12345')
+      })
+
+      it('should resolve with the result of the tag', function () {
+        expect(result).to.be.equal(info)
+      })
+    })
+
+    describe('when scope is "none"', function () {
+      beforeEach(function () {
+        info.scope = 'none'
+        return bumper._maybeCreateTag(info)
+          .then((res) => {
+            result = res
+          })
+      })
+
+      it('should not create a tag', function () {
+        expect(bumper.ci.tag).to.have.callCount(0)
+      })
+
+      it('should resolve with the result of the tag', function () {
+        expect(result).to.be.equal(info)
+      })
+    })
+  })
+
+  describe('._maybeGenerateDependencyComplianceReport()', function () {
+    let result, info
+    beforeEach(function () {
+      info = {
+        modifiedFiles: [],
+        scope: 'none'
+      }
+    })
+
+    describe('when no dir is configured', function () {
+      beforeEach(function () {
+        return bumper._maybeGenerateDependencyComplianceReport(info)
+          .then((r) => {
+            result = r
+          })
+      })
+
+      it('should log info about skipping b/c of config', function () {
+        const msg = 'Skipping generating dependency compliance report because of config option.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not generate dependencies', function () {
+        expect(depStub.run).to.have.callCount(0)
+      })
+
+      it('should return a promise resolving with info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+
+    describe('when an out dir is configured, but scope is "none"', function () {
+      beforeEach(function () {
+        __.set(bumper.config, 'dependencies.output.directory', 'blackduck/')
+        return bumper._maybeGenerateDependencyComplianceReport(info)
+          .then((r) => {
+            result = r
+          })
+      })
+
+      it('should log info about skipping b/c of scope', function () {
+        const msg = 'Skipping generating dependency compliance report because of "none" scope.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not generate dependencies', function () {
+        expect(depStub.run).to.have.callCount(0)
+      })
+
+      it('should return a promise resolving with info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+
+    describe('when an out dir is configured, and scope is not "none"', function () {
+      let cwd, globalPath
+      beforeEach(function () {
+        info.scope = 'patch'
+        cwd = process.cwd()
+        globalPath = path.join(cwd, 'blackduck/')
+        __.set(bumper.config, 'dependencies.output.directory', 'blackduck/')
+        return bumper._maybeGenerateDependencyComplianceReport(info)
+          .then((r) => {
+            result = r
+          })
+      })
+
+      it('should not log anything', function () {
+        expect(logger.log).to.have.callCount(0)
+      })
+
+      it('should generate dependencies', function () {
+        expect(depStub.run).to.have.been.calledWith(cwd, globalPath, bumper.config)
+      })
+
+      it('should add "blackduck/" to the list of files modified', function () {
+        expect(info.modifiedFiles).to.include('blackduck/')
+      })
+
+      it('should return a promise resolving with info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+  })
+
+  describe('._maybeGenerateDependencySnapshot()', function () {
+    let ret, info
+    beforeEach(function () {
+      info = {
+        modifiedFiles: [],
+        scope: 'patch'
+      }
+      bumper.config.dependencySnapshotFile = 'snapshot-file'
+      execStub.withArgs('npm prune').returns(Promise.resolve('prune-done'))
+      execStub.withArgs('npm shrinkwrap --dev').returns(Promise.resolve('shrinkwrap-done'))
+      execStub.returns(Promise.resolve('move-done'))
+    })
+
+    describe('when no snapshot file defined', function () {
+      beforeEach(function () {
+        bumper.config.dependencySnapshotFile = ''
+        return bumper._maybeGenerateDependencySnapshot(info)
+          .then((resp) => {
+            ret = resp
+          })
+      })
+
+      it('should log a message about why it is skipping', function () {
+        const msg = 'Skipping generating dependency snapshot because of config option.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not prune node_modules so shrinkwrap will work', function () {
+        expect(execStub).not.to.have.been.calledWith('npm prune')
+      })
+
+      it('should not generate the dependency snapshot', function () {
+        expect(execStub).not.to.have.been.calledWith('npm shrinkwrap --dev')
+      })
+
+      it('should not add the dependencySnapshotFile to the list of modified files', function () {
+        expect(info.modifiedFiles).to.have.length(0)
+      })
+
+      it('should return the info', function () {
+        expect(ret).to.equal(info)
+      })
+    })
+
+    describe('when scope is "none"', function () {
+      beforeEach(function () {
+        info.scope = 'none'
+        return bumper._maybeGenerateDependencySnapshot(info)
+          .then((resp) => {
+            ret = resp
+          })
+      })
+
+      it('should log a message about why it is skipping', function () {
+        const msg = 'Skipping generating dependency snapshot because of "none" scope.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not prune node_modules so shrinkwrap will work', function () {
+        expect(execStub).not.to.have.been.calledWith('npm prune')
+      })
+
+      it('should not generate the dependency snapshot', function () {
+        expect(execStub).not.to.have.been.calledWith('npm shrinkwrap --dev')
+      })
+
+      it('should not add the dependencySnapshotFile to the list of modified files', function () {
+        expect(info.modifiedFiles).to.have.length(0)
+      })
+
+      it('should return the info', function () {
+        expect(ret).to.equal(info)
+      })
+    })
+
+    describe('when snapshot file defined and scope is not "none"', function () {
+      beforeEach(function () {
+        return bumper._maybeGenerateDependencySnapshot(info)
+          .then((resp) => {
+            ret = resp
+          })
+      })
+
+      it('should prune node_modules so shrinkwrap will work', function () {
+        expect(execStub).to.have.been.calledWith('npm prune')
+      })
+
+      it('should generate the dependency snapshot', function () {
+        expect(execStub).to.have.been.calledWith('npm shrinkwrap --dev')
+      })
+
+      it('should rename the dependency snapshot', function () {
+        expect(execStub).to.have.been.calledWith('mv npm-shrinkwrap.json snapshot-file')
+      })
+
+      it('should add the dependencySnapshotFile to the list of modified files', function () {
+        expect(info.modifiedFiles).to.include(bumper.config.dependencySnapshotFile)
+      })
+
+      it('should return the info', function () {
+        expect(ret).to.equal(info)
+      })
+    })
+  })
+
+  describe('._maybePrependChangelog()', function () {
+    let result, info
+    beforeEach(function () {
+      info = {
+        changelog: 'the-changelog-content',
+        scope: 'patch',
+        modifiedFiles: [],
+        version: '1.2.3'
+      }
+      prependStub.returns(Promise.resolve('return-value'))
+    })
+
+    describe('when prependChangelog is false', function () {
+      beforeEach(function () {
+        bumper.config.prependChangelog = false
+        bumper.config.changelogFile = 'the-changelog-file'
+
+        return bumper._maybePrependChangelog(info)
+          .then((resp) => {
+            result = resp
+          })
+      })
+
+      it('should log a message explaining why it is skipping', function () {
+        const msg = 'Skipping prepending changelog because of config option.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not prepend the changelog', function () {
+        expect(prependStub).to.have.callCount(0)
+      })
+
+      it('should not add the changelog file to the modifiedFiles list', function () {
+        expect(info.modifiedFiles).not.to.include('the-changelog-file')
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+
+    describe('when scope is "none"', function () {
+      beforeEach(function () {
+        info.scope = 'none'
+        delete info.version
+        bumper.config.prependChangelog = true
+        bumper.config.changelogFile = 'the-changelog-file'
+
+        return bumper._maybePrependChangelog(info)
+          .then((resp) => {
+            result = resp
+          })
+      })
+
+      it('should log a message explaining why it is skipping', function () {
+        const msg = 'Skipping prepending changelog because of "none" scope.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not prepend the changelog', function () {
+        expect(prependStub).to.have.callCount(0)
+      })
+
+      it('should not add the changelog file to the modifiedFiles list', function () {
+        expect(info.modifiedFiles).not.to.include('the-changelog-file')
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+
+    describe('when prependChangelog is true and scope is not "none"', function () {
+      beforeEach(function () {
+        info.scope = 'patch'
+        bumper.config.prependChangelog = true
+        bumper.config.changelogFile = 'the-changelog-file'
+
+        return bumper._maybePrependChangelog(info)
+          .then((resp) => {
+            result = resp
+          })
+      })
+
+      it('should not log a message explaining why it is skipping', function () {
+        expect(logger.log).to.have.callCount(0)
+      })
+
+      it('should prepend the changelog', function () {
+        const data = `# ${info.version}\n${info.changelog}\n\n`
+        expect(prependStub).to.have.been.calledWith('the-changelog-file', data)
+      })
+
+      it('should add the changelog file to the modifiedFiles list', function () {
+        expect(info.modifiedFiles).to.include('the-changelog-file')
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+  })
+
+  describe('_maybePushChanges()', function () {
+    let result, info
+    beforeEach(function () {
+      info = {
+        modifiedFiles: [],
+        scope: 'none'
+      }
+      bumper.ci = {
+        push: sandbox.stub().returns(Promise.resolve('pushed'))
+      }
+    })
+
+    describe('when nothing changed', function () {
+      beforeEach(function () {
+        return bumper._maybePushChanges(info)
+          .then((r) => {
+            result = r
+          })
+      })
+
+      it('should log a message about why it is skipping', function () {
+        expect(logger.log).to.have.been.calledWith('Skipping push because nothing changed.')
+      })
+
+      it('should not push the change', function () {
+        expect(bumper.ci.push).to.have.callCount(0)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+
+    describe('when something changed', function () {
+      beforeEach(function () {
+        info.modifiedFiles = ['package.json']
+        return bumper._maybePushChanges(info)
+          .then((r) => {
+            result = r
+          })
+      })
+
+      it('should not log a message about why it is skipping', function () {
+        expect(logger.log).to.have.callCount(0)
+      })
+
+      it('should push the change', function () {
+        expect(bumper.ci.push).to.have.been.calledWith(bumper.vcs)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+    })
+  })
+
+  describe('_maybeUpdateBaselineCoverage()', function () {
+    let info, _pkgJson, result, error
+    beforeEach(function () {
+      info = {
+        modifiedFiles: [],
+        scope: 'none'
+      }
+
+      writeFileStub.returns(Promise.resolve('written'))
+      sandbox.stub(utils, 'getCurrentCoverage')
+    })
+
+    describe('when no baseline coverage present', function () {
+      beforeEach(function (done) {
+        _pkgJson = {}
+
+        result = error = null
+        bumper._maybeUpdateBaselineCoverage(info, _pkgJson)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should log a message about why it is not updating coverage', function () {
+        const msg = 'Skipping updating baseline code coverage because no valid coverage found.'
+        expect(logger.log).to.have.been.calledWith(msg)
+      })
+
+      it('should not lookup current coverage', function () {
+        expect(utils.getCurrentCoverage).to.have.callCount(0)
+      })
+
+      it('should not write to a file', function () {
+        expect(writeFileStub).to.have.callCount(0)
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+    })
+
+    describe('when no current coverage present', function () {
+      beforeEach(function (done) {
+        _pkgJson = {}
+        bumper.config.baselineCoverage = 99.93
+        utils.getCurrentCoverage.returns(-1)
+
+        result = error = null
+        bumper._maybeUpdateBaselineCoverage(info, _pkgJson)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should lookup current coverage', function () {
+        expect(utils.getCurrentCoverage).to.have.callCount(1)
+      })
+
+      it('should not write to a file', function () {
+        expect(writeFileStub).to.have.callCount(0)
+      })
+
+      it('should not add "package.json" to the list of modified files', function () {
+        expect(info.modifiedFiles).not.to.include('package.json')
+      })
+
+      it('should not resolve', function () {
+        expect(result).to.equal(null)
+      })
+
+      it('should reject with an appropriate error', function () {
+        const link = 'https://github.com/ciena-blueplanet/pr-bumper#code-coverage'
+        const msg = `No current coverage info found!\nSee ${link} for configuration info.`
+        expect(error).to.equal(msg)
+      })
+    })
+
+    describe('when current coverage and baseline present', function () {
+      beforeEach(function (done) {
+        _pkgJson = {
+          foo: 'bar',
+          'pr-bumper': {
+            coverage: 99.15
+          }
+        }
+
+        bumper.config.baselineCoverage = 99.15
+        utils.getCurrentCoverage.returns(99.57)
+        writeFileStub.returns(Promise.resolve('written'))
+        result = error = null
+        bumper._maybeUpdateBaselineCoverage(info, _pkgJson)
+          .then((r) => {
+            result = r
+          })
+          .catch((e) => {
+            error = e
+          })
+          .finally(() => {
+            done()
+          })
+      })
+
+      it('should lookup current coverage', function () {
+        expect(utils.getCurrentCoverage).to.have.callCount(1)
+      })
+
+      it('should update the coverage in the contents of the package.json', function () {
+        expect(_pkgJson['pr-bumper'].coverage).to.equal(99.57)
+      })
+
+      it('should write new contents of the "package.json" file', function () {
+        const location = path.join(process.cwd(), 'package.json')
+        expect(writeFileStub).to.have.been.calledWith(location, JSON.stringify(_pkgJson, null, 2))
+      })
+
+      it('should add "package.json" to the list of modified files', function () {
+        expect(info.modifiedFiles).to.include('package.json')
+      })
+
+      it('should resolve with the info', function () {
+        expect(result).to.equal(info)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
     })
   })
 })

--- a/tests/ci/base-spec.js
+++ b/tests/ci/base-spec.js
@@ -152,4 +152,23 @@ describe('CiBase', function () {
       expect(result).to.be.equal('executed')
     })
   })
+
+  describe('.tag()', function () {
+    let result
+    beforeEach(function () {
+      execStub.returns(Promise.resolve('tagged'))
+      return base.tag('v1.2.3', 'Super-cool tag description')
+        .then((res) => {
+          result = res
+        })
+    })
+
+    it('should create the tag', function () {
+      expect(execStub).to.have.been.calledWith('git tag v1.2.3 -a -m "Super-cool tag description"')
+    })
+
+    it('should resolve with the result of the exec call', function () {
+      expect(result).to.equal('tagged')
+    })
+  })
 })

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -50,7 +50,8 @@ describe('Cli', function () {
     beforeEach(function () {
       bumper = {
         bump: sandbox.stub().returns(Promise.resolve('bumped')),
-        check: sandbox.stub().returns(Promise.resolve('checked'))
+        check: sandbox.stub().returns(Promise.resolve('checked')),
+        checkCoverage: sandbox.stub().returns(Promise.resolve('coverage-checked'))
       }
 
       sandbox.stub(utils, 'getConfig').returns({id: 'config'})
@@ -140,6 +141,50 @@ describe('Cli', function () {
 
       it('should resolve with the result of check', function () {
         expect(result).to.be.equal('checked')
+      })
+
+      it('should not error', function () {
+        expect(error).to.equal('')
+      })
+    })
+
+    describe('check-coverage', function () {
+      beforeEach(function () {
+        result = ''
+        error = ''
+
+        return cli
+          .run('check-coverage')
+          .then((res) => {
+            result = res
+          })
+          .catch((err) => {
+            error = err
+          })
+      })
+
+      it('should get the config', function () {
+        expect(utils.getConfig).to.have.callCount(1)
+      })
+
+      it('should get the vcs', function () {
+        expect(cli._getVcs).to.have.been.calledWith({id: 'config'})
+      })
+
+      it('should get the ci', function () {
+        expect(cli._getCi).to.have.been.calledWith({id: 'config'}, {id: 'vcs'})
+      })
+
+      it('should get the bumper', function () {
+        expect(cli._getBumper).to.have.been.calledWith({
+          ci: {id: 'ci'},
+          config: {id: 'config'},
+          vcs: {id: 'vcs'}
+        })
+      })
+
+      it('should resolve with the result of check', function () {
+        expect(result).to.be.equal('coverage-checked')
       })
 
       it('should not error', function () {

--- a/tests/logger-spec.js
+++ b/tests/logger-spec.js
@@ -6,6 +6,7 @@ const sinonChai = require('sinon-chai')
 const expect = chai.expect
 chai.use(sinonChai)
 
+const pkgJson = require('../package.json')
 const logger = require('../lib/logger')
 
 describe('logger', function () {
@@ -14,7 +15,7 @@ describe('logger', function () {
     it('should log to console', function () {
       stub = sinon.stub(console, 'log')
       logger.log('foo bar baz')
-      expect(console.log).to.have.been.calledWith('foo bar baz')
+      expect(console.log).to.have.been.calledWith(`${pkgJson.name}: foo bar baz`)
       stub.restore()
     })
   })
@@ -23,7 +24,7 @@ describe('logger', function () {
     it('should log to console', function () {
       stub = sinon.stub(console, 'error')
       logger.error('foo bar baz')
-      expect(console.error).to.have.been.calledWith('foo bar baz')
+      expect(console.error).to.have.been.calledWith(`${pkgJson.name}: foo bar baz`)
       stub.restore()
     })
   })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -108,6 +108,12 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
         expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
       })
     }
+
+    if (propsToSkip.indexOf('changelogFile') === -1) {
+      it('should default changelogFile to "CHANGELOG.md"', function () {
+        expect(config.changelogFile).to.equal('CHANGELOG.md')
+      })
+    }
   })
   /* eslint-enable complexity */
 }
@@ -165,6 +171,10 @@ function verifyBitbucketTeamcityOverrides (ctx) {
 
     it('should default dependencySnapshotFile to "dependency-snapshot.json"', function () {
       expect(config.dependencySnapshotFile).to.equal('dependency-snapshot.json')
+    })
+
+    it('should default changelogFile to "CHANGELOG.md"', function () {
+      expect(config.changelogFile).to.equal('CHANGELOG.md')
     })
   })
 }

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -49,7 +49,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
 
     if (propsToSkip.indexOf('ci.gitUser') === -1) {
       it('should use the proper git user', function () {
-        expect(config.ci.gitUser).to.be.eql({
+        expect(config.ci.gitUser).to.eql({
           email: 'travis.ci.ciena@gmail.com',
           name: 'Travis CI'
         })
@@ -58,43 +58,43 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
 
     if (propsToSkip.indexOf('ci.provider') === -1) {
       it('should use the proper ci provider', function () {
-        expect(config.ci.provider).to.be.equal('travis')
+        expect(config.ci.provider).to.equal('travis')
       })
     }
 
     if (propsToSkip.indexOf('owner') === -1) {
       it('should have the proper owner', function () {
-        expect(config.owner).to.be.equal('jdoe')
+        expect(config.owner).to.equal('jdoe')
       })
     }
 
     if (propsToSkip.indexOf('branch') === -1) {
       it('should have the proper branch', function () {
-        expect(config.branch).to.be.equal('my-branch')
+        expect(config.branch).to.equal('my-branch')
       })
     }
 
     if (propsToSkip.indexOf('repo') === -1) {
       it('should have the proper repo', function () {
-        expect(config.repo).to.be.equal('john-and-jane')
+        expect(config.repo).to.equal('john-and-jane')
       })
     }
 
     if (propsToSkip.indexOf('vcs.domain') === -1) {
       it('should have the proper vcs domain', function () {
-        expect(config.vcs.domain).to.be.equal('github.com')
+        expect(config.vcs.domain).to.equal('github.com')
       })
     }
 
     if (propsToSkip.indexOf('vcs.provider') === -1) {
       it('should have the proper vcs provider', function () {
-        expect(config.vcs.provider).to.be.equal('github')
+        expect(config.vcs.provider).to.equal('github')
       })
     }
 
     if (propsToSkip.indexOf('vcs.auth') === -1) {
       it('should have the proper vcs auth', function () {
-        expect(config.vcs.auth).to.be.eql({
+        expect(config.vcs.auth).to.eql({
           password: undefined,
           readToken: '12345',
           username: undefined,
@@ -124,38 +124,38 @@ function verifyBitbucketTeamcityOverrides (ctx) {
     })
 
     it('should have the proper git user', function () {
-      expect(config.ci.gitUser).to.be.eql({
+      expect(config.ci.gitUser).to.eql({
         email: 'teamcity@domain.com',
         name: 'teamcity'
       })
     })
 
     it('should have the proper ci provider', function () {
-      expect(config.ci.provider).to.be.equal('teamcity')
+      expect(config.ci.provider).to.equal('teamcity')
     })
 
     it('should have the proper owner', function () {
-      expect(config.owner).to.be.equal('my-project')
+      expect(config.owner).to.equal('my-project')
     })
 
     it('should have the proper repo', function () {
-      expect(config.repo).to.be.equal('my-repo')
+      expect(config.repo).to.equal('my-repo')
     })
 
     it('should have the proper branch', function () {
-      expect(config.branch).to.be.equal('my-branch')
+      expect(config.branch).to.equal('my-branch')
     })
 
     it('should have the proper vcs domain', function () {
-      expect(config.vcs.domain).to.be.equal('bitbucket.domain.com')
+      expect(config.vcs.domain).to.equal('bitbucket.domain.com')
     })
 
     it('should have the proper vcs provider', function () {
-      expect(config.vcs.provider).to.be.equal('bitbucket-server')
+      expect(config.vcs.provider).to.equal('bitbucket-server')
     })
 
     it('should have the proper vcs auth', function () {
-      expect(config.vcs.auth).to.be.eql({
+      expect(config.vcs.auth).to.eql({
         password: 'teamcity12345',
         readToken: undefined,
         username: 'teamcity',
@@ -204,14 +204,14 @@ describe('utils', function () {
         }
       })
 
-      describe('when doing a pull request build', function () {
+      describe('when doing a pull request build (w/o coverage in package.json)', function () {
         beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = '13'
 
           saveEnv(Object.keys(env), realEnv)
           setEnv(env)
 
-          config = utils.getConfig()
+          config = utils.getConfig(null, {})
           ctx.config = config
         })
 
@@ -222,18 +222,53 @@ describe('utils', function () {
         })
 
         it('should set prNumber to the PR number', function () {
-          expect(config.prNumber).to.be.equal('13')
+          expect(config.prNumber).to.equal('13')
+        })
+
+        it('should not have a baselineCoverage set', function () {
+          expect(config.baselineCoverage).to.equal(undefined)
         })
       })
 
-      describe('when doing a merge build', function () {
+      describe('when doing a pull request build (with coverage in package.json)', function () {
+        beforeEach(function () {
+          env.TRAVIS_PULL_REQUEST = '13'
+
+          saveEnv(Object.keys(env), realEnv)
+          setEnv(env)
+
+          const pkgJson = {
+            'pr-bumper': {
+              coverage: 85.93
+            }
+          }
+          config = utils.getConfig(null, pkgJson)
+          ctx.config = config
+        })
+
+        verifyGitHubTravisDefaults(ctx)
+
+        it('should set isPr to true', function () {
+          expect(config.isPr).to.equal(true)
+        })
+
+        it('should set prNumber to the PR number', function () {
+          expect(config.prNumber).to.equal('13')
+        })
+
+        it('should set baselineCoverage to the coverage from package.json', function () {
+          expect(config.baselineCoverage).to.equal(85.93)
+        })
+      })
+
+      describe('when doing a merge build (w/o coverage in package.json)', function () {
         beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = 'false'
 
           saveEnv(Object.keys(env), realEnv)
           setEnv(env)
 
-          config = utils.getConfig()
+          config = utils.getConfig(null, {})
           ctx.config = config
         })
 
@@ -244,7 +279,42 @@ describe('utils', function () {
         })
 
         it('should set prNumber to false', function () {
-          expect(config.prNumber).to.be.equal('false')
+          expect(config.prNumber).to.equal('false')
+        })
+
+        it('should not have a baselineCoverage set', function () {
+          expect(config.baselineCoverage).to.equal(undefined)
+        })
+      })
+
+      describe('when doing a merge build (with coverage in package.json)', function () {
+        beforeEach(function () {
+          const pkgJson = {
+            'pr-bumper': {
+              coverage: 85.93
+            }
+          }
+          env.TRAVIS_PULL_REQUEST = 'false'
+
+          saveEnv(Object.keys(env), realEnv)
+          setEnv(env)
+
+          config = utils.getConfig(null, pkgJson)
+          ctx.config = config
+        })
+
+        verifyGitHubTravisDefaults(ctx)
+
+        it('should set isPr to false', function () {
+          expect(config.isPr).to.equal(false)
+        })
+
+        it('should set prNumber to false', function () {
+          expect(config.prNumber).to.equal('false')
+        })
+
+        it('should set baselineCoverage to the coverage from package.json', function () {
+          expect(config.baselineCoverage).to.equal(85.93)
         })
       })
 
@@ -270,7 +340,7 @@ describe('utils', function () {
         verifyGitHubTravisDefaults(ctx, ['ci.gitUser'])
 
         it('should use the overwritten git user', function () {
-          expect(config.ci.gitUser).to.be.eql({
+          expect(config.ci.gitUser).to.eql({
             email: 'some.other.user@domain.com',
             name: 'Some Other User'
           })
@@ -280,7 +350,7 @@ describe('utils', function () {
 
     describe('GitHubEnterprise/Travis', function () {
       const ctx = {}
-      let _config
+      let _config, _pkgJson
       beforeEach(function () {
         _config = {
           ci: {
@@ -295,6 +365,12 @@ describe('utils', function () {
           }
         }
 
+        _pkgJson = {
+          'pr-bumper': {
+            coverage: 98.03
+          }
+        }
+
         env = {
           'TRAVIS_BRANCH': 'my-branch',
           'TRAVIS_BUILD_NUMBER': '123',
@@ -304,14 +380,14 @@ describe('utils', function () {
         }
       })
 
-      describe('when doing a pull request build', function () {
+      describe('when doing a pull request build (w/o coverage in package.json)', function () {
         beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = '13'
 
           saveEnv(Object.keys(env), realEnv)
           setEnv(env)
 
-          config = utils.getConfig(_config)
+          config = utils.getConfig(_config, {})
           ctx.config = config
         })
 
@@ -337,18 +413,63 @@ describe('utils', function () {
         })
 
         it('should set prNumber to the PR number', function () {
-          expect(config.prNumber).to.be.equal('13')
+          expect(config.prNumber).to.equal('13')
+        })
+
+        it('should not have a baselineCoverage set', function () {
+          expect(config.baselineCoverage).to.equal(undefined)
         })
       })
 
-      describe('when doing a merge build', function () {
+      describe('when doing a pull request build (with coverage in package.json)', function () {
+        beforeEach(function () {
+          env.TRAVIS_PULL_REQUEST = '13'
+
+          saveEnv(Object.keys(env), realEnv)
+          setEnv(env)
+
+          config = utils.getConfig(_config, _pkgJson)
+          ctx.config = config
+        })
+
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+
+        it('should have the proper gitUser', function () {
+          expect(config.ci.gitUser).to.eql({
+            email: 'bot@domain.com',
+            name: 'Bot User'
+          })
+        })
+
+        it('should have the proper vcs.domain', function () {
+          expect(config.vcs.domain).to.equal('ghe.domain.com')
+        })
+
+        it('should have the proper vcs.provider', function () {
+          expect(config.vcs.provider).to.equal('github-enterprise')
+        })
+
+        it('should set isPr to true', function () {
+          expect(config.isPr).to.equal(true)
+        })
+
+        it('should set prNumber to the PR number', function () {
+          expect(config.prNumber).to.equal('13')
+        })
+
+        it('should set baselineCoverage to the coverage from package.json', function () {
+          expect(config.baselineCoverage).to.equal(98.03)
+        })
+      })
+
+      describe('when doing a merge build (w/o coverage in package.json)', function () {
         beforeEach(function () {
           env.TRAVIS_PULL_REQUEST = 'false'
 
           saveEnv(Object.keys(env), realEnv)
           setEnv(env)
 
-          config = utils.getConfig(_config)
+          config = utils.getConfig(_config, {})
           ctx.config = config
         })
 
@@ -374,7 +495,52 @@ describe('utils', function () {
         })
 
         it('should set prNumber to false', function () {
-          expect(config.prNumber).to.be.equal('false')
+          expect(config.prNumber).to.equal('false')
+        })
+
+        it('should not have a baselineCoverage set', function () {
+          expect(config.baselineCoverage).to.equal(undefined)
+        })
+      })
+
+      describe('when doing a merge build (with coverage in package.json)', function () {
+        beforeEach(function () {
+          env.TRAVIS_PULL_REQUEST = 'false'
+
+          saveEnv(Object.keys(env), realEnv)
+          setEnv(env)
+
+          config = utils.getConfig(_config, _pkgJson)
+          ctx.config = config
+        })
+
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+
+        it('should have the proper gitUser', function () {
+          expect(config.ci.gitUser).to.eql({
+            email: 'bot@domain.com',
+            name: 'Bot User'
+          })
+        })
+
+        it('should have the proper vcs.domain', function () {
+          expect(config.vcs.domain).to.equal('ghe.domain.com')
+        })
+
+        it('should have the proper vcs.provider', function () {
+          expect(config.vcs.provider).to.equal('github-enterprise')
+        })
+
+        it('should set isPr to false', function () {
+          expect(config.isPr).to.equal(false)
+        })
+
+        it('should set prNumber to false', function () {
+          expect(config.prNumber).to.equal('false')
+        })
+
+        it('should set baselineCoverage to the coverage from package.json', function () {
+          expect(config.baselineCoverage).to.equal(98.03)
         })
       })
     })
@@ -441,7 +607,7 @@ describe('utils', function () {
         })
 
         it('should set prNumber to the PR number', function () {
-          expect(config.prNumber).to.be.equal('13')
+          expect(config.prNumber).to.equal('13')
         })
       })
 
@@ -462,7 +628,7 @@ describe('utils', function () {
         })
 
         it('should set prNumber to false', function () {
-          expect(config.prNumber).to.be.equal('false')
+          expect(config.prNumber).to.equal('false')
         })
       })
 
@@ -477,7 +643,7 @@ describe('utils', function () {
         })
 
         it('should default to master branch', function () {
-          expect(config.branch).to.be.equal('master')
+          expect(config.branch).to.equal('master')
         })
       })
     })
@@ -498,7 +664,7 @@ describe('utils', function () {
 
     __.forIn(scopes, (value, key) => {
       it(`handles ${key}`, function () {
-        expect(utils.getValidatedScope(key, prNum, prUrl)).to.be.equal(value)
+        expect(utils.getValidatedScope(key, prNum, prUrl)).to.equal(value)
       })
     })
 
@@ -557,11 +723,11 @@ describe('utils', function () {
       })
 
       it('should call .getValidatedScope() with proper arguments', function () {
-        expect(utils.getValidatedScope.lastCall.args).to.be.eql(['feature', '12345', 'my-pr-url'])
+        expect(utils.getValidatedScope.lastCall.args).to.eql(['feature', '12345', 'my-pr-url'])
       })
 
       it('should return the result of .getValidatedScope()', function () {
-        expect(scope).to.be.equal('the-validated-scope')
+        expect(scope).to.equal('the-validated-scope')
       })
     })
 
@@ -578,7 +744,7 @@ describe('utils', function () {
       })
 
       it('should call .getValidatedScope() with proper arguments', function () {
-        expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
+        expect(utils.getValidatedScope.lastCall.args).to.eql(['minor', '12345', 'my-pr-url'])
       })
     })
 
@@ -616,7 +782,7 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
 
       it('should call .getValidatedScope() with proper arguments', function () {
-        expect(utils.getValidatedScope.lastCall.args).to.be.eql(['minor', '12345', 'my-pr-url'])
+        expect(utils.getValidatedScope.lastCall.args).to.eql(['minor', '12345', 'my-pr-url'])
       })
     })
   })
@@ -678,7 +844,7 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
 
       it('should grab the changelog text', function () {
-        expect(changelog).to.be.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+        expect(changelog).to.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
       })
     })
 
@@ -689,7 +855,40 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
 
       it('should grab the changelog text', function () {
-        expect(changelog).to.be.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+        expect(changelog).to.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+      })
+    })
+  })
+
+  describe('.getCurrentCoverage()', function () {
+    let cov, pct
+    beforeEach(function () {
+      cov = {
+        total: {
+          lines: {
+            pct: 95.98
+          }
+        }
+      }
+    })
+
+    describe('when no coverage present', function () {
+      beforeEach(function () {
+        pct = utils.getCurrentCoverage({})
+      })
+
+      it('should return -1', function () {
+        expect(pct).to.equal(-1)
+      })
+    })
+
+    describe('when coverage is present', function () {
+      beforeEach(function () {
+        pct = utils.getCurrentCoverage(cov)
+      })
+
+      it('should return the total line pct', function () {
+        expect(pct).to.equal(95.98)
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** the ability to ensure code coverage does not decrease because of a PR. Simply add your project's current code coverage in `package.json` under: 
  ```js
  "pr-bumper": {
    "coverage": 95.93
  }
   ``` 
  Then add a `pr-bumper check-coverage` call to your CI. The `check-coverage` command will fail if the current code coverage is below the baseline in your `package.json`.  
  
  **NOTE**: You must place the `pr-bumper check-coverage` line **after** you run your tests, or `pr-bumper` will not be able to find the current code coverage information to check against the baseline, and your build will fail regardless of your code coverage. 
  
  During a `pr-bumper bump` command, the current coverage will be saved to `package.json`

* **Added** the ability to customize the name of the changelog file to prepend (defaults to `CHANGELOG.md` still). 
* **Added** a `[pr-bumper]` prefix to all commits made by `pr-bumper` so they can be easily identified. 
* **Added** a `pr-bumper: ` prefix to all messages logged to the console by `pr-bumper` so they can be easily identified. 
* **Added** initial coverage baseline to `package.json` within this project to enable code coverage check. 
* **Added** `check-coverage` check after the build. 
* **Added** `.travis/maybe-check-coverage.sh` script to wrap a call to `pr-bumper check-coverage` and skip it if the commit being built is a `pr-bumper` commit.
* **Updated** how `.travis/is-bump-commit.sh` verifies that a commit came from `pr-bumper` to match the new prefix being used by `pr-bumper` for commits. 