### PR TITLE
Add date stamp to changelog, fix bug in bump

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -8,7 +8,7 @@ const prependFile = require('prepend-file')
 const Promise = require('promise')
 const versiony = require('versiony')
 const path = require('path')
-const fsWriteFile = require('fs').writeFile
+const fs = require('fs')
 
 const pkgJson = require('../package.json')
 
@@ -18,7 +18,8 @@ let dependencies = require('./compliance/dependencies')
 // using let so stuff can be rewired in the test
 let exec = Promise.denodeify(cpExec)
 let prepend = Promise.denodeify(prependFile)
-let writeFile = Promise.denodeify(fsWriteFile)
+let readFile = Promise.denodeify(fs.readFile)
+let writeFile = Promise.denodeify(fs.writeFile)
 
 const logger = require('./logger')
 const utils = require('./utils')
@@ -396,7 +397,10 @@ class Bumper {
       return Promise.resolve(info)
     }
 
-    const data = `# ${info.version}\n${info.changelog}\n\n`
+    const now = new Date()
+    const dateString = now.toISOString().split('T').slice(0, 1).join('')
+
+    const data = `# ${info.version} (${dateString})\n${info.changelog}\n\n`
     return prepend(this.config.changelogFile, data)
       .then(() => {
         addModifiedFile(info, this.config.changelogFile)
@@ -424,10 +428,9 @@ class Bumper {
   /**
    * Maybe update the code coverage in package.json
    * @param {PrInfo} info - the info for the PR being bumped
-   * @param {Object} _pkgJson - the contents of `package.json` for the project being bumped (used for testing)
    * @returns {Promise} a Promise
    **/
-  _maybeUpdateBaselineCoverage (info, _pkgJson) {
+  _maybeUpdateBaselineCoverage (info) {
     const base = this.config.baselineCoverage
     if (!__.isNumber(base)) {
       logger.log('Skipping updating baseline code coverage because no valid coverage found.')
@@ -441,15 +444,17 @@ class Bumper {
       return Promise.reject(msg)
     }
 
-    let pkgJsonContents = _pkgJson
     const pkgJsonPath = path.join(process.cwd(), 'package.json')
-    if (!pkgJsonContents) {
-      pkgJsonContents = require(pkgJsonPath)
-    }
 
-    pkgJsonContents['pr-bumper'].coverage = pct
-
-    return writeFile(pkgJsonPath, JSON.stringify(pkgJsonContents, null, 2))
+    return readFile(pkgJsonPath, 'utf8')
+      .then((contents) => {
+        const pkgJsonContents = JSON.parse(contents)
+        pkgJsonContents['pr-bumper'].coverage = pct
+        return JSON.stringify(pkgJsonContents, null, 2)
+      })
+      .then((data) => {
+        return writeFile(pkgJsonPath, data)
+      })
       .then(() => {
         addModifiedFile(info, 'package.json')
         return info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-bumper",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Bump the version of a package based on a GitHub Pull Request",
   "scripts": {
     "lint": "eslint *.js bin lib tests",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** a date string (ISO standard `YYYY-MM-DD`) to the title line when prepending changelog with a new version. 
* **Fixed** bug where version bump in `package.json` was being overwritten by coverage update.