### PR TITLE
Add ability to create PR comments

### DIFF
--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,3 +1,0 @@
-{
-  "prComments": true
-}

--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,0 +1,3 @@
+{
+  "prComments": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,30 @@
 # 1.7.0 (2017-03-14)
-* **Added** a date string (ISO standard `YYYY-MM-DD`) to the title line when prepending changelog with a new version. 
-* **Fixed** bug where version bump in `package.json` was being overwritten by coverage update.
+* **Added** a date string (ISO standard `YYYY-MM-DD`) to the title line when prepending changelog with a new version.
+* **Fixed** bug where version bump in `package.json` was being overwritten by coverage update  [#89](https://github.com/ciena-blueplanet/pr-bumper/issues/89).
 
-# 1.6.0
-* **Added** the ability to ensure code coverage does not decrease because of a PR. Simply add your project's current code coverage in `package.json` under: 
+# 1.6.0 (never published due to [#89](https://github.com/ciena-blueplanet/pr-bumper/issues/89))
+* **Added** the ability to ensure code coverage does not decrease because of a PR. Simply add your project's current code coverage in `package.json` under:
   ```js
   "pr-bumper": {
     "coverage": 95.93
   }
-   ``` 
+   ```
   Then add a `pr-bumper check-coverage` call to your CI. The `check-coverage` command will fail if the current code coverage is below the baseline in your `package.json`.  
-  
-  **NOTE**: You must place the `pr-bumper check-coverage` line **after** you run your tests, or `pr-bumper` will not be able to find the current code coverage information to check against the baseline, and your build will fail regardless of your code coverage. 
-  
+
+  **NOTE**: You must place the `pr-bumper check-coverage` line **after** you run your tests, or `pr-bumper` will not be able to find the current code coverage information to check against the baseline, and your build will fail regardless of your code coverage.
+
   During a `pr-bumper bump` command, the current coverage will be saved to `package.json`
 
-* **Added** the ability to customize the name of the changelog file to prepend (defaults to `CHANGELOG.md` still). 
-* **Added** a `[pr-bumper]` prefix to all commits made by `pr-bumper` so they can be easily identified. 
-* **Added** a `pr-bumper: ` prefix to all messages logged to the console by `pr-bumper` so they can be easily identified. 
-* **Added** initial coverage baseline to `package.json` within this project to enable code coverage check. 
-* **Added** `check-coverage` check after the build. 
+* **Added** the ability to customize the name of the changelog file to prepend (defaults to `CHANGELOG.md` still).
+* **Added** a `[pr-bumper]` prefix to all commits made by `pr-bumper` so they can be easily identified.
+* **Added** a `pr-bumper: ` prefix to all messages logged to the console by `pr-bumper` so they can be easily identified.
+* **Added** initial coverage baseline to `package.json` within this project to enable code coverage check.
+* **Added** `check-coverage` check after the build.
 * **Added** `.travis/maybe-check-coverage.sh` script to wrap a call to `pr-bumper check-coverage` and skip it if the commit being built is a `pr-bumper` commit.
-* **Updated** how `.travis/is-bump-commit.sh` verifies that a commit came from `pr-bumper` to match the new prefix being used by `pr-bumper` for commits. 
+* **Updated** how `.travis/is-bump-commit.sh` verifies that a commit came from `pr-bumper` to match the new prefix being used by `pr-bumper` for commits.
 
 # 1.5.0
-* **Improved** application of default values when processing `.pr-bumper.json`. Whereas previously you would have to provide an entire, complex, nested object if you wanted to override the default for any part of a config object, you can now override a partial object in your `.pr-bumper.json` and the rest of the object will get the appropriate defaults. 
+* **Improved** application of default values when processing `.pr-bumper.json`. Whereas previously you would have to provide an entire, complex, nested object if you wanted to override the default for any part of a config object, you can now override a partial object in your `.pr-bumper.json` and the rest of the object will get the appropriate defaults.
 
 
 # 1.4.0
@@ -81,11 +81,11 @@
 
 
 # 1.1.3
-* **Fixed** issue where `npm shrinkwrap` was being called w/o `--dev` so not all dependencies were actually being accounted for in the snapshot. This is particularly important in things like ember apps where everything is in `devDependencies`. 
+* **Fixed** issue where `npm shrinkwrap` was being called w/o `--dev` so not all dependencies were actually being accounted for in the snapshot. This is particularly important in things like ember apps where everything is in `devDependencies`.
 
 
 # 1.1.2
- * **Updated** tests to run in `node@5.0.0` and `node@6.9.1` and only publish after success on `node@6.9.1`. 
+ * **Updated** tests to run in `node@5.0.0` and `node@6.9.1` and only publish after success on `node@6.9.1`.
 
 
 # 1.1.1
@@ -96,11 +96,11 @@
 
 
 # 1.0.0
- * **Fixed** #44 by throwing an error when `# CHANGELOG` is missing/empty unless `prependChangelog` is set to `false`.  This is a **breaking** change as previously missing `# CHANGELOG` sections would result in a default message in the `CHANGELOG.md` file. 
+ * **Fixed** #44 by throwing an error when `# CHANGELOG` is missing/empty unless `prependChangelog` is set to `false`.  This is a **breaking** change as previously missing `# CHANGELOG` sections would result in a default message in the `CHANGELOG.md` file.
 
 
 # 0.7.4
-* **Addedd** another test to try out codecov.io reporting. 
+* **Addedd** another test to try out codecov.io reporting.
 
 # 0.7.3
 * **Attempted** to switch from [coveralls.io](http://coveralls.io) to [codecov.io](http://codecov.io)
@@ -111,7 +111,7 @@
 
 
 # 0.7.1
-* **Fixed** #55 
+* **Fixed** #55
 
 
 
@@ -126,7 +126,7 @@
       "reposFile": "repos",
       "ignoreFile": "ignore"
     },
-    production: false, 
+    production: false,
     "additionalRepos": [
           {
             "pattern": "\\s+\"(ember\\-frost\\-\\S+)\"",
@@ -188,12 +188,12 @@ You can now configure `pr-bumper` to work with something other than Travis CI an
 }
 ```
 ## `ci.env.buildNumber`
-A string that provides the environment variable that holds the TeamCity build number on the agent that runs your build. One way to set that variable is with the following in your Build Step: 
+A string that provides the environment variable that holds the TeamCity build number on the agent that runs your build. One way to set that variable is with the following in your Build Step:
 ```
 export TEAMCITY_BUILD_NUMBER="%teamcity.build.id%"
 ```
 ## `ci.env.pr`
-A string that provides the environment variable that holds the PR number of the pull request being built (empty when a not a PR build). One way to fill that variable is by including the following in your Build Step: 
+A string that provides the environment variable that holds the PR number of the pull request being built (empty when a not a PR build). One way to fill that variable is by including the following in your Build Step:
 ```
 stripped_branch=\$(echo "%teamcity.build.branch%" | sed -e "s/\/merge//")
 re='^[0-9]+$'
@@ -231,7 +231,7 @@ Here you configure what VCS system you use, the only currently supported options
 Format the `CHANGELOG.md` file properly by adding some newlines after the prepended entry.
 
 # 0.4.1
- * Fixes issue where `\r` characters in the pr description weren't properly handled. Who knew GitHub was built on Windows? ;) 
+ * Fixes issue where `\r` characters in the pr description weren't properly handled. Who knew GitHub was built on Windows? ;)
  * Fixes issue where users had to be extremely specific with their `# CHANGELOG` section heading. The following are now all valid as well: `#CHANGELOG`, `# CHANGELOG  `, `#changelog `, `# changelog`
 
 # 0.4.0

--- a/README.md
+++ b/README.md
@@ -77,9 +77,28 @@ That would indicate to `pr-bumper` that the current coverage for your repository
 below that will fail the `pr-bumper check-coverage` check, and can then fail your CI build if you include the running
 of `pr-bumper check-coverage` in your CI (after your tests run and coverage is reported of course).
 
-The "current" coverage that `pr-bumper` will compare against this "baseline" will be read from the file at `coverage/coverage-summary.json`. This can be populated using the `json-summary` reporter from `istanbul`.
+The "current" coverage that `pr-bumper` will compare against this "baseline" will be read from the file at
+`coverage/coverage-summary.json`. This can be populated using the `json-summary` reporter from `istanbul`.
 There are a number of statistics in `coverage-summary.json`, but the one that `pr-bumper` looks at is the total
 percentage of lines covered, or `total.lines.pct`.
+
+### Pull Request comments
+`pr-bumper` can post information to the pull request it is checking. This does not happen by default, but can be
+turned on by enabling the `prComments` flag in `.pr-bumper.json`:
+
+```json
+"prComments": true
+```
+
+When that flag is set, `pr-bumper` will post comments to pull requests in the following situations:
+
+**NOTE** The changelog and code coverage comments are only made if those features are enabled.
+##### Errors
+ * If no valid PR scope is found in the PR description
+ * If no `# CHANGELOG` section is found in the PR description
+ * If code coverage decreases, it will indicate the delta, the previous value and the current value
+##### information
+ * When code coverage does not decrese, it will indicate the delta, the previous value and the current value
 
 ## Integrations
 `pr-bumper` currently supports pull requests on [GitHub][github-url], and [Bitbucket Server][bitbucket-url]
@@ -137,9 +156,15 @@ Add the following snippet to your `.travis.yml` file to integrate `pr-bumper`
 
 This will allow `pr-bumper` to be installed for your build, allow it to check for the existence of version-bump
 comments on your PRs, as well as allow it to automatically version-bump and git tag your releases before you deploy
-them. You'll notice that in the *deploy* section we tell Travis to deploy for all branches when a tag is part of the commit. The way this works is when you merge a pull request the merge build will run the tests as well as the pr-bumper bump command. As part of this build a new commit will be pushed back to your VCS firing off two new builds, one for the branch and one for the tag. The build for the branch will be exited as soon as possible as we don't care about that build. The build for the tag is where the actual deployment to npm will occur.
+them. You'll notice that in the *deploy* section we tell Travis to deploy for all branches when a tag is part of the
+commit. The way this works is when you merge a pull request the merge build will run the tests as well as the
+`pr-bumper bump` command. As part of this build a new commit will be pushed back to your VCS firing off two new builds,
+one for the branch and one for the tag. The build for the branch will be exited as soon as possible as we don't care
+about that build. The build for the tag is where the actual deployment to npm will occur.
 
-*NOTE: The above snippet uses the scripts from this project itself which may or may not suite your needs. If you find one of the scripts doesn't do exactly what you need, then copy it directly into your project, modify it, and update the Travis config to run you modified copy instead.*
+*NOTE: The above snippet uses the scripts from this project itself which may or may not suite your needs. If you find
+one of the scripts doesn't do exactly what you need, then copy it directly into your project, modify it, and update
+the Travis config to run you modified copy instead.*
 
 Before `pr-bumper` can push commits and tags back to your repository however, you need to set up authentication.
 
@@ -163,7 +188,8 @@ Otherwise, replace the `owner/repo` with the organization and repo of your `upst
 [env-docs]: https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
 Also, to avoid rate-limit issues on API requests to github, you should also specify a `RO_GH_TOKEN`
 for `pr-bumper` to use when making read requests to github. This is necessary because secure environment variables are
-not available to pull request builds when coming from forks in travis for [security reasons][env-docs].
+not available to pull request builds when coming from forks in travis for [security reasons][env-docs]. The
+`RO_GH_TOKEN` will also be required if you opt-in to having `pr-bumper` post comments to your pull requests.
 
 > **NOTE** Since `RO_GH_TOKEN` is not secure, it is printed directly into your Travis Logs!!!
 > So, make sure it has only read access to your repository. Hence the name `RO_GH_TOKEN` (Read Only GitHub Token)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The "current" coverage that `pr-bumper` will compare against this "baseline" wil
 There are a number of statistics in `coverage-summary.json`, but the one that `pr-bumper` looks at is the total
 percentage of lines covered, or `total.lines.pct`.
 
-### Pull Request comments
+### Pull Request comments (except on github.com)
 `pr-bumper` can post information to the pull request it is checking. This does not happen by default, but can be
 turned on by enabling the `prComments` flag in `.pr-bumper.json`:
 
@@ -99,6 +99,12 @@ When that flag is set, `pr-bumper` will post comments to pull requests in the fo
  * If code coverage decreases, it will indicate the delta, the previous value and the current value
 ##### information
  * When code coverage does not decrese, it will indicate the delta, the previous value and the current value
+
+As mentioned in the heading, PR comments do not currently work on github.com. This is because during the PR build
+`pr-bumper` does not have access to a user token with sufficient permissions to allow creation of a comment on
+an issue. We're investigating ways to allow this without having to publish a token with write permissions as
+a public variable in Travis, but for now the feature is only usable in private scenarios
+(github enterprise and bitbucket server).
 
 ## Integrations
 `pr-bumper` currently supports pull requests on [GitHub][github-url], and [Bitbucket Server][bitbucket-url]

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -133,13 +133,19 @@ class Bumper {
     const base = this.config.baselineCoverage
     if (!__.isNumber(base)) {
       const msg = `No baseline coverage info found!\nSee ${link} for configuration info.`
-      return Promise.reject(msg)
+      return utils.maybePostComment(this.config, this.vcs, msg)
+        .then(() => {
+          return Promise.reject(msg)
+        })
     }
 
     const pct = utils.getCurrentCoverage()
     if (pct < 0) {
       const msg = `No current coverage info found!\nSee ${link} for configuration info.`
-      return Promise.reject(msg)
+      return utils.maybePostComment(this.config, this.vcs, msg)
+        .then(() => {
+          return Promise.reject(msg)
+        })
     }
 
     if (base > pct) {
@@ -147,12 +153,15 @@ class Bumper {
       const baseStr = base.toFixed(2)
       const pctStr = pct.toFixed(2)
       const msg = `Coverage dropped ${diffStr}% (from ${baseStr}% to ${pctStr}%) in this PR!`
-      return Promise.reject(msg)
+      return utils.maybePostComment(this.config, this.vcs, msg)
+        .then(() => {
+          return Promise.reject(msg)
+        })
     }
 
     const msg = this._getCoverageMsg(base, pct)
     logger.log(msg)
-    return Promise.resolve()
+    return utils.maybePostComment(this.config, this.vcs, msg)
   }
 
   // = Private Methods ==================================================================
@@ -226,13 +235,23 @@ class Bumper {
     const vcs = this.vcs
     return vcs.getPr(this.config.prNumber)
       .then((pr) => {
-        const scope = utils.getScopeForPr(pr)
+        let scope
+        return utils.maybePostCommentOnError(this.config, this.vcs, () => {
+          scope = utils.getScopeForPr(pr)
+          return {pr, scope}
+        })
+      })
+      .then(({pr, scope}) => {
         const getChangelog = this.config.prependChangelog && scope !== 'none'
-
-        return {
-          changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
-          scope: scope
+        let changelog = ''
+        if (getChangelog) {
+          return utils.maybePostCommentOnError(this.config, this.vcs, () => {
+            changelog = utils.getChangelogForPr(pr)
+            return {changelog, scope}
+          })
         }
+
+        return Promise.resolve({changelog, scope})
       })
   }
 

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -241,7 +241,10 @@ class Bumper {
           return {pr, scope}
         })
       })
-      .then(({pr, scope}) => {
+      .then((data) => {
+        const pr = data.pr
+        const scope = data.scope
+
         const getChangelog = this.config.prependChangelog && scope !== 'none'
         let changelog = ''
         if (getChangelog) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -155,6 +155,7 @@ const utils = {
         },
         provider: 'github'
       },
+      prComments: false,
       prependChangelog: true
     }
 
@@ -278,12 +279,64 @@ const utils = {
   getCurrentCoverage (_coverageSummary) {
     let coverageSummary = _coverageSummary
     if (!coverageSummary) {
+      // TODO: should we maybe make this use readFile and make it async? (ARM 2017-03-14)
       coverageSummary = require(path.join(process.cwd(), 'coverage/coverage-summary.json'))
     }
 
     const pct = __.get(coverageSummary, 'total.lines.pct') || -1
 
     return pct
+  },
+
+  /**
+   * Maybe post a comment to the PR, if prComments is enabled
+   * @param {Object} config - the bumper config
+   * @param {Vcs} vcs - the vcs instance for the bumper
+   * @param {String} msg - the message to post
+   * @returns {Promise} a promise resolved when success, rejected on error
+   */
+  maybePostComment (config, vcs, msg) {
+    if (config.prComments) {
+      return vcs.postComment(config.prNumber, msg)
+        .catch((err) => {
+          const newMessage = `Received error: ${err.message} while trying to post PR comment about: ${msg}`
+          throw new Error(newMessage)
+        })
+    }
+
+    return Promise.resolve()
+  },
+
+  /**
+   * Maybe post a comment to the PR, if the function given throws an error, and prComments is enabled
+   * @param {Object} config - the config for a bumper instance
+   * @param {Vcs} vcs - the vcs instance for a bumper instance
+   * @param {Function} func - the function to execute and check for errors on
+   * @returns {Promise} a promise resolved if all goes well, rejected if an error is thrown
+   */
+  maybePostCommentOnError (config, vcs, func) {
+    let ret
+    try {
+      ret = func()
+    } catch (e) {
+      if (config.prComments) {
+        return vcs.postComment(config.prNumber, e.message)
+          .then(() => {
+            throw e
+          })
+          .catch((err) => {
+            if (err !== e) {
+              const msg = `Received error: ${err.message} while trying to post PR comment about error: ${e.message}`
+              throw new Error(msg)
+            }
+
+            throw e
+          })
+      }
+      return Promise.reject(e)
+    }
+
+    return Promise.resolve(ret)
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -296,7 +296,7 @@ const utils = {
    * @returns {Promise} a promise resolved when success, rejected on error
    */
   maybePostComment (config, vcs, msg) {
-    if (config.prComments) {
+    if (config.isPr && config.prComments) {
       return vcs.postComment(config.prNumber, msg)
         .catch((err) => {
           const newMessage = `Received error: ${err.message} while trying to post PR comment about: ${msg}`
@@ -319,7 +319,7 @@ const utils = {
     try {
       ret = func()
     } catch (e) {
-      if (config.prComments) {
+      if (config.isPr && config.prComments) {
         return vcs.postComment(config.prNumber, e.message)
           .then(() => {
             throw e

--- a/lib/vcs/bitbucket-server.js
+++ b/lib/vcs/bitbucket-server.js
@@ -67,12 +67,37 @@ class BitbucketServer {
     return fetch(url)
       .then((resp) => {
         if (!resp.ok) {
-          throw new Error(`${resp.status}: ${JSON.stringify(resp.json, null, 2)}`)
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
         }
         return resp.json()
       })
       .then((bbPr) => {
         return convertPr(bbPr)
+      })
+  }
+
+  /**
+   * Post a comment to the given PR
+   * @param {String} prNumber - the PR number (i.e. 31)
+   * @param {String} comment - the comment body
+   * @returns {Promise} a promise resolved with result of posting the comment
+   */
+  postComment (prNumber, comment) {
+    const owner = this.config.owner
+    const repo = this.config.repo
+    const url = `${this.baseUrl}/projects/${owner}/repos/${repo}/pull-requests/${prNumber}/comments`
+    const safeUrl = url.replace(/https:\/\/[^:]+:[^@]+@/, 'https://')
+    logger.log(`About to send POST to ${safeUrl}`)
+
+    return fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({text: comment}),
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then((resp) => {
+        if (!resp.ok) {
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
+        }
       })
   }
 }

--- a/lib/vcs/github-enterprise.js
+++ b/lib/vcs/github-enterprise.js
@@ -93,12 +93,36 @@ class GitHubEnterprise {
     return fetch(url, getFetchOpts(this.config))
       .then((resp) => {
         if (!resp.ok) {
-          throw new Error(`${resp.status}: ${JSON.stringify(resp.json, null, 2)}`)
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
         }
         return resp.json()
       })
       .then((ghPr) => {
         return convertPr(ghPr)
+      })
+  }
+
+  /**
+   * Post a comment to the given PR
+   * @param {String} prNumber - the PR number (i.e. 31)
+   * @param {String} comment - the comment body
+   * @returns {Promise} a promise resolved with result of posting the comment
+   */
+  postComment (prNumber, comment) {
+    const owner = this.config.owner
+    const repo = this.config.repo
+    const url = `${this.baseUrl}/repos/${owner}/${repo}/issues/${prNumber}/comments`
+    logger.log(`About to send POST to ${url}`)
+
+    return fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({body: comment}),
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then((resp) => {
+        if (!resp.ok) {
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
+        }
       })
   }
 }

--- a/lib/vcs/github.js
+++ b/lib/vcs/github.js
@@ -90,12 +90,36 @@ class GitHub {
     return fetch(url, getFetchOpts(this.config))
       .then((resp) => {
         if (!resp.ok) {
-          throw new Error(`${resp.status}: ${JSON.stringify(resp.json, null, 2)}`)
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
         }
         return resp.json()
       })
       .then((ghPr) => {
         return convertPr(ghPr)
+      })
+  }
+
+  /**
+   * Post a comment to the given PR
+   * @param {String} prNumber - the PR number (i.e. 31)
+   * @param {String} comment - the comment body
+   * @returns {Promise} a promise resolved with result of posting the comment
+   */
+  postComment (prNumber, comment) {
+    const owner = this.config.owner
+    const repo = this.config.repo
+    const url = `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`
+    logger.log(`About to send POST to ${url}`)
+
+    return fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({body: comment}),
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then((resp) => {
+        if (!resp.ok) {
+          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
+        }
       })
   }
 }

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -934,6 +934,7 @@ Thought this might be #breaking# but on second thought it is a minor change
     let config, resolver, vcs, result, error
     beforeEach(function () {
       config = {
+        isPr: true,
         prComments: false,
         prNumber: '123'
       }
@@ -980,7 +981,37 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
     })
 
-    describe('and prComments is true', function () {
+    describe('when prComments is true, but isPr is false', function () {
+      beforeEach(function (done) {
+        config.isPr = false
+        config.prComments = true
+        utils.maybePostComment(config, vcs, 'fizz-bang')
+          .then((resp) => {
+            result = resp
+          })
+          .catch((err) => {
+            error = err
+          })
+
+        setTimeout(() => {
+          done()
+        }, 0)
+      })
+
+      it('should not post a comment', function () {
+        expect(vcs.postComment).to.have.callCount(0)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve', function () {
+        expect(result).to.equal(undefined)
+      })
+    })
+
+    describe('and prComments is true and isPr is true', function () {
       let promise
       beforeEach(function () {
         config.prComments = true
@@ -1045,6 +1076,7 @@ Thought this might be #breaking# but on second thought it is a minor change
     let config, resolver, vcs, func, result, error
     beforeEach(function () {
       config = {
+        isPr: true,
         prComments: false,
         prNumber: '123'
       }
@@ -1128,9 +1160,41 @@ Thought this might be #breaking# but on second thought it is a minor change
         })
       })
 
-      describe('and prComments is true', function () {
+      describe('and prComments is true but isPr is false', function () {
+        beforeEach(function (done) {
+          config.isPr = false
+          config.prComments = true
+          utils.maybePostCommentOnError(config, vcs, func)
+            .then((resp) => {
+              result = resp
+            })
+            .catch((err) => {
+              error = err
+              done()
+            })
+        })
+
+        it('should call the func', function () {
+          expect(func).to.have.callCount(1)
+        })
+
+        it('should not post a comment', function () {
+          expect(vcs.postComment).to.have.callCount(0)
+        })
+
+        it('should reject with the error thrown', function () {
+          expect(error).to.eql(new Error('Uh oh!'))
+        })
+
+        it('should not resolve', function () {
+          expect(result).to.equal(null)
+        })
+      })
+
+      describe('and prComments is true and isPr is true', function () {
         let promise
         beforeEach(function () {
+          config.isPr = true
           config.prComments = true
           promise = utils.maybePostCommentOnError(config, vcs, func)
             .then((resp) => {

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -114,6 +114,12 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
         expect(config.changelogFile).to.equal('CHANGELOG.md')
       })
     }
+
+    if (propsToSkip.indexOf('prComments') === -1) {
+      it('should default prComments to false', function () {
+        expect(config.prComments).to.equal(false)
+      })
+    }
   })
   /* eslint-enable complexity */
 }
@@ -175,6 +181,10 @@ function verifyBitbucketTeamcityOverrides (ctx) {
 
     it('should default changelogFile to "CHANGELOG.md"', function () {
       expect(config.changelogFile).to.equal('CHANGELOG.md')
+    })
+
+    it('should default prComments to false', function () {
+      expect(config.prComments).to.equal(false)
     })
   })
 }
@@ -372,7 +382,8 @@ describe('utils', function () {
           vcs: {
             domain: 'ghe.domain.com',
             provider: 'github-enterprise'
-          }
+          },
+          prComments: true
         }
 
         _pkgJson = {
@@ -401,7 +412,7 @@ describe('utils', function () {
           ctx.config = config
         })
 
-        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider', 'prComments'])
 
         it('should have the proper gitUser', function () {
           expect(config.ci.gitUser).to.eql({
@@ -428,6 +439,10 @@ describe('utils', function () {
 
         it('should not have a baselineCoverage set', function () {
           expect(config.baselineCoverage).to.equal(undefined)
+        })
+
+        it('should have the proper prComments value', function () {
+          expect(config.prComments).to.equal(true)
         })
       })
 
@@ -442,7 +457,7 @@ describe('utils', function () {
           ctx.config = config
         })
 
-        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider', 'prComments'])
 
         it('should have the proper gitUser', function () {
           expect(config.ci.gitUser).to.eql({
@@ -470,6 +485,10 @@ describe('utils', function () {
         it('should set baselineCoverage to the coverage from package.json', function () {
           expect(config.baselineCoverage).to.equal(98.03)
         })
+
+        it('should have the proper prComments value', function () {
+          expect(config.prComments).to.equal(true)
+        })
       })
 
       describe('when doing a merge build (w/o coverage in package.json)', function () {
@@ -483,7 +502,7 @@ describe('utils', function () {
           ctx.config = config
         })
 
-        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider', 'prComments'])
 
         it('should have the proper gitUser', function () {
           expect(config.ci.gitUser).to.eql({
@@ -511,6 +530,10 @@ describe('utils', function () {
         it('should not have a baselineCoverage set', function () {
           expect(config.baselineCoverage).to.equal(undefined)
         })
+
+        it('should have the proper prComments value', function () {
+          expect(config.prComments).to.equal(true)
+        })
       })
 
       describe('when doing a merge build (with coverage in package.json)', function () {
@@ -524,7 +547,7 @@ describe('utils', function () {
           ctx.config = config
         })
 
-        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider'])
+        verifyGitHubTravisDefaults(ctx, ['ci.gitUser', 'vcs.domain', 'vcs.provider', 'prComments'])
 
         it('should have the proper gitUser', function () {
           expect(config.ci.gitUser).to.eql({
@@ -551,6 +574,10 @@ describe('utils', function () {
 
         it('should set baselineCoverage to the coverage from package.json', function () {
           expect(config.baselineCoverage).to.equal(98.03)
+        })
+
+        it('should have the proper prComments value', function () {
+          expect(config.prComments).to.equal(true)
         })
       })
     })
@@ -899,6 +926,272 @@ Thought this might be #breaking# but on second thought it is a minor change
 
       it('should return the total line pct', function () {
         expect(pct).to.equal(95.98)
+      })
+    })
+  })
+
+  describe('.maybePostComment()', function () {
+    let config, resolver, vcs, result, error
+    beforeEach(function () {
+      config = {
+        prComments: false,
+        prNumber: '123'
+      }
+
+      resolver = {}
+      resolver.promise = new Promise((resolve, reject) => {
+        resolver.resolve = resolve
+        resolver.reject = reject
+      })
+
+      vcs = {
+        postComment: sandbox.stub().returns(resolver.promise)
+      }
+
+      result = error = null
+    })
+
+    describe('when prComments is false', function () {
+      beforeEach(function (done) {
+        config.prComments = false
+        utils.maybePostComment(config, vcs, 'fizz-bang')
+          .then((resp) => {
+            result = resp
+          })
+          .catch((err) => {
+            error = err
+          })
+
+        setTimeout(() => {
+          done()
+        }, 0)
+      })
+
+      it('should not post a comment', function () {
+        expect(vcs.postComment).to.have.callCount(0)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve', function () {
+        expect(result).to.equal(undefined)
+      })
+    })
+
+    describe('and prComments is true', function () {
+      let promise
+      beforeEach(function () {
+        config.prComments = true
+        promise = utils.maybePostComment(config, vcs, 'fizz-bang')
+          .then((resp) => {
+            result = resp
+          })
+          .catch((err) => {
+            error = err
+            throw err
+          })
+      })
+
+      it('should post a comment', function () {
+        expect(vcs.postComment).to.have.been.calledWith(config.prNumber, 'fizz-bang')
+      })
+
+      it('should not reject yet', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should not resolve yet', function () {
+        expect(result).to.equal(null)
+      })
+
+      describe('when postComment succeeds', function () {
+        beforeEach(function () {
+          resolver.resolve()
+          return promise
+        })
+
+        it('should not reject', function () {
+          expect(error).to.equal(null)
+        })
+
+        it('should resolve', function () {
+          expect(result).to.equal(undefined)
+        })
+      })
+
+      describe('when postComment fails', function () {
+        beforeEach(function (done) {
+          resolver.reject(new Error('Aw snap!'))
+          promise.catch(() => {
+            done()
+          })
+        })
+
+        it('should reject with a combined error', function () {
+          const msg = 'Received error: Aw snap! while trying to post PR comment about: fizz-bang'
+          expect(error.message).to.equal(msg)
+        })
+
+        it('should not resolve', function () {
+          expect(result).to.equal(null)
+        })
+      })
+    })
+  })
+
+  describe('.maybePostCommentOnError()', function () {
+    let config, resolver, vcs, func, result, error
+    beforeEach(function () {
+      config = {
+        prComments: false,
+        prNumber: '123'
+      }
+
+      resolver = {}
+      resolver.promise = new Promise((resolve, reject) => {
+        resolver.resolve = resolve
+        resolver.reject = reject
+      })
+
+      vcs = {
+        postComment: sandbox.stub().returns(resolver.promise)
+      }
+
+      func = sandbox.stub()
+      result = error = null
+    })
+
+    describe('when func succeeds', function () {
+      beforeEach(function () {
+        func.returns('foo')
+        return utils.maybePostCommentOnError(config, vcs, func)
+          .then((resp) => {
+            result = resp
+          })
+          .catch((err) => {
+            error = err
+            throw err
+          })
+      })
+
+      it('should call the func', function () {
+        expect(func).to.have.callCount(1)
+      })
+
+      it('should not post a comment', function () {
+        expect(vcs.postComment).to.have.callCount(0)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve with the return value of func', function () {
+        expect(result).to.equal('foo')
+      })
+    })
+
+    describe('when func throws an error', function () {
+      beforeEach(function () {
+        func.throws(new Error('Uh oh!'))
+      })
+
+      describe('and prComments is false', function () {
+        beforeEach(function (done) {
+          config.prComments = false
+          utils.maybePostCommentOnError(config, vcs, func)
+            .then((resp) => {
+              result = resp
+            })
+            .catch((err) => {
+              error = err
+              done()
+            })
+        })
+
+        it('should call the func', function () {
+          expect(func).to.have.callCount(1)
+        })
+
+        it('should not post a comment', function () {
+          expect(vcs.postComment).to.have.callCount(0)
+        })
+
+        it('should reject with the error thrown', function () {
+          expect(error).to.eql(new Error('Uh oh!'))
+        })
+
+        it('should not resolve', function () {
+          expect(result).to.equal(null)
+        })
+      })
+
+      describe('and prComments is true', function () {
+        let promise
+        beforeEach(function () {
+          config.prComments = true
+          promise = utils.maybePostCommentOnError(config, vcs, func)
+            .then((resp) => {
+              result = resp
+            })
+            .catch((err) => {
+              error = err
+              throw err
+            })
+        })
+
+        it('should call the func', function () {
+          expect(func).to.have.callCount(1)
+        })
+
+        it('should post a comment', function () {
+          expect(vcs.postComment).to.have.been.calledWith(config.prNumber, 'Uh oh!')
+        })
+
+        it('should not reject yet', function () {
+          expect(error).to.equal(null)
+        })
+
+        it('should not resolve', function () {
+          expect(result).to.equal(null)
+        })
+
+        describe('when postComment succeeds', function () {
+          beforeEach(function (done) {
+            resolver.resolve()
+            promise.catch(() => {
+              done()
+            })
+          })
+
+          it('should reject with the original error', function () {
+            expect(error.message).to.equal('Uh oh!')
+          })
+
+          it('should not resolve', function () {
+            expect(result).to.equal(null)
+          })
+        })
+
+        describe('when postComment fails', function () {
+          beforeEach(function (done) {
+            resolver.reject(new Error('Aw snap!'))
+            promise.catch(() => {
+              done()
+            })
+          })
+
+          it('should reject with a combined error', function () {
+            const msg = 'Received error: Aw snap! while trying to post PR comment about error: Uh oh!'
+            expect(error.message).to.equal(msg)
+          })
+
+          it('should not resolve', function () {
+            expect(result).to.equal(null)
+          })
+        })
       })
     })
   })

--- a/tests/vcs/github-spec.js
+++ b/tests/vcs/github-spec.js
@@ -60,6 +60,25 @@ describe('GitHub', function () {
     expect(github.config).to.be.eql(config)
   })
 
+  describe('.addRemoteForPush()', function () {
+    let remoteName
+    beforeEach(function () {
+      execStub.returns(Promise.resolve())
+      return github.addRemoteForPush().then((name) => {
+        remoteName = name
+      })
+    })
+
+    it('should makes the proper git remote command', function () {
+      const url = 'https://my-gh-token@github.com/me/my-repo'
+      expect(execStub.firstCall.args).to.be.eql([`git remote add ci-origin ${url}`])
+    })
+
+    it('should resolve with the proper remote name', function () {
+      expect(remoteName).to.be.equal('ci-origin')
+    })
+  })
+
   describe('.getPr()', function () {
     let resolution, rejection, promise, fetchResolver
     beforeEach(function () {
@@ -71,6 +90,7 @@ describe('GitHub', function () {
 
       fetchStub.returns(fetchPromise)
 
+      resolution = rejection = null
       promise = github.getPr('5')
         .then((resp) => {
           resolution = resp
@@ -93,7 +113,7 @@ describe('GitHub', function () {
       )
     })
 
-    describe('when fetch succeeds', function () {
+    describe('when fetch resolves with success', function () {
       let resp
       beforeEach(function (done) {
         resp = {ok: true, status: 200, json: function () {}}
@@ -124,6 +144,31 @@ describe('GitHub', function () {
       })
     })
 
+    describe('when fetch resolves with error', function () {
+      let resp, err
+      beforeEach(function (done) {
+        resp = {ok: false, status: 400, json () {}}
+        err = {
+          message: 'Uh oh'
+        }
+        sandbox.stub(resp, 'json').returns(Promise.resolve(err))
+
+        promise.catch(() => {
+          done()
+        })
+
+        fetchResolver.resolve(resp)
+      })
+
+      it('should not resolve', function () {
+        expect(resolution).to.equal(null)
+      })
+
+      it('should reject with the proper error', function () {
+        expect(rejection).to.be.eql(new Error(`400: ${JSON.stringify(err)}`))
+      })
+    })
+
     describe('when fetch errors', function () {
       beforeEach(function (done) {
         promise.catch(() => {
@@ -139,22 +184,92 @@ describe('GitHub', function () {
     })
   })
 
-  describe('.addRemoteForPush()', function () {
-    let remoteName
+  describe('.postComment()', function () {
+    let resolution, rejection, promise, fetchResolver
     beforeEach(function () {
-      execStub.returns(Promise.resolve())
-      return github.addRemoteForPush().then((name) => {
-        remoteName = name
+      fetchResolver = {}
+      let fetchPromise = new Promise((resolve, reject) => {
+        fetchResolver.resolve = resolve
+        fetchResolver.reject = reject
+      })
+
+      fetchStub.returns(fetchPromise)
+
+      resolution = rejection = null
+      promise = github.postComment('5', 'Missing PR scope!')
+        .then((resp) => {
+          resolution = resp
+          return resolution
+        })
+        .catch((err) => {
+          rejection = err
+          throw err
+        })
+    })
+
+    it('should call fetch with proper params', function () {
+      const url = 'https://api.github.com/repos/me/my-repo/issues/5/comments'
+      expect(fetchStub).to.have.been.calledWith(url, {
+        method: 'POST',
+        body: JSON.stringify({body: 'Missing PR scope!'}),
+        headers: {'Content-Type': 'application/json'}
       })
     })
 
-    it('should makes the proper git remote command', function () {
-      const url = 'https://my-gh-token@github.com/me/my-repo'
-      expect(execStub.firstCall.args).to.be.eql([`git remote add ci-origin ${url}`])
+    describe('when fetch resolves with success', function () {
+      beforeEach(function (done) {
+        promise.then(() => {
+          done()
+        })
+        fetchResolver.resolve({ok: true})
+      })
+
+      it('should resolve', function () {
+        expect(resolution).to.equal(undefined)
+      })
     })
 
-    it('should resolve with the proper remote name', function () {
-      expect(remoteName).to.be.equal('ci-origin')
+    describe('when fetch resolves with error', function () {
+      let resp, err
+      beforeEach(function (done) {
+        err = {message: 'Uh oh'}
+        resp = {
+          ok: false,
+          status: 400,
+          json () {
+            return err
+          }
+        }
+        promise.catch(() => {
+          done()
+        })
+        fetchResolver.resolve(resp)
+      })
+
+      it('should not resolve', function () {
+        expect(resolution).to.equal(null)
+      })
+
+      it('should reject with proper error', function () {
+        expect(rejection).to.eql(new Error(`400: ${JSON.stringify(err)}`))
+      })
+    })
+
+    describe('when fetch rejects', function () {
+      beforeEach(function (done) {
+        promise.catch(() => {
+          done()
+        })
+        fetchResolver.reject('Uh oh')
+      })
+
+      it('should not resolve', function () {
+        expect(resolution).to.equal(null)
+      })
+
+      it('should reject with proper error', function () {
+        expect(rejection).to.equal('Uh oh')
+      })
     })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** ability to post comments to pull requests in certain scenarios. By default this behavior is off, it can be enabled by adding:
  ```json
  "prComments": true
  ```
  to your `.pr-bumper.json` config.
  **Sadly** this feature does not currently work in github.com/travis scenarios. Mainly because `pr-bumper` doesn't have sufficient permissions during the PR build to post a comment on the PR. We're trying to find a way around that, but in the meantime, at least the feature can be used in bitbucket server / teamcity scenarios. 