### PR TITLE
Cleaned up logging messages and fixed cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Use text from a pull request description to automatically bump the version numbe
 ## Pull Requests
 `pr-bumper` uses [Semantic Versioning](http://semver.org/).
 
-Pull requests must include a directive indicating the
-scope of the change being made (`major`/`minor`/`patch`/`none`). Directives are **case insensitive** and wrapped in `#` to
-avoid a description such as
+Pull request descriptions must include a directive indicating the scope of the change being made
+(`major`/`minor`/`patch`/`none`). Directives are **case insensitive** and wrapped in `#` to avoid a description such as
 
 ```
 Fixing a major bug in the code
@@ -62,6 +61,43 @@ will know exactly what to do before the build fails.
 [travis-url]: https://travis-ci.org
 [teamcity-url]: https://www.jetbrains.com/teamcity/
 
+### CHANGELOG
+`pr-bumper` includes support for managing your `CHANGELOG.md` file for you. This feature is enabled by default, but
+can be disabled by setting `prependChangelog` to `false` in `.pr-bumper.json`:
+
+```json
+"prependChangelog": false
+```
+
+You can also change the name of your changelog file from `CHANGELOG.md` to something else using the `changelogFile`
+property in `.pr-bumper.json`:
+
+```json
+"changelogFile": "CHANGES.md"
+```
+
+When `prependChangelog` is `true` (the default), `pr-bumper` will ensure that a `# CHANGELOG` section exists in your
+PR description during the `pr-bumper check`. Then, during a `pr-bumper bump` it will take all the content below the
+`# CHANGELOG` line, and prepend it to the `CHANGELOG.md` (or whatever file is configured). It will give this new
+content a heading with the newly bumped version number, along with the date (in ISO `yyy-mm-dd` format, based on UTC)
+
+So, if your project is at version `1.2.3` and you have a PR description that looks like:
+
+```
+This is a new #feature#
+
+# CHANGELOG
+ * **Added** the ability to do fizz-bang
+```
+
+that is merged on January 15th, 2017, `pr-bumper` will prepend your `CHANGELOG.md` with the following:
+
+```
+# 1.3.0 (2017-01-15)
+ * **Added** the ability to do fizz-bang
+
+```
+
 ### Code Coverage
 `pr-bumper` supports ensuring that code coverage is not decreasing because of a pull request. This is achieved by
 comparing the current code coverage against a saved "baseline" coverage percentage. Enabling this feature is done
@@ -82,7 +118,9 @@ The "current" coverage that `pr-bumper` will compare against this "baseline" wil
 There are a number of statistics in `coverage-summary.json`, but the one that `pr-bumper` looks at is the total
 percentage of lines covered, or `total.lines.pct`.
 
-### Pull Request comments (except on github.com)
+### Pull Request comments
+> **EXCEPT** on github.com
+
 `pr-bumper` can post information to the pull request it is checking. This does not happen by default, but can be
 turned on by enabling the `prComments` flag in `.pr-bumper.json`:
 
@@ -100,7 +138,7 @@ When that flag is set, `pr-bumper` will post comments to pull requests in the fo
 ##### information
  * When code coverage does not decrese, it will indicate the delta, the previous value and the current value
 
-As mentioned in the heading, PR comments do not currently work on github.com. This is because during the PR build
+As mentioned above, PR comments do not currently work on github.com. This is because during the PR build
 `pr-bumper` does not have access to a user token with sufficient permissions to allow creation of a comment on
 an issue. We're investigating ways to allow this without having to publish a token with write permissions as
 a public variable in Travis, but for now the feature is only usable in private scenarios

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -133,7 +133,7 @@ class Bumper {
     const base = this.config.baselineCoverage
     if (!__.isNumber(base)) {
       const msg = `No baseline coverage info found!\nSee ${link} for configuration info.`
-      return utils.maybePostComment(this.config, this.vcs, msg)
+      return utils.maybePostComment(this.config, this.vcs, msg, true)
         .then(() => {
           return Promise.reject(msg)
         })
@@ -142,7 +142,7 @@ class Bumper {
     const pct = utils.getCurrentCoverage()
     if (pct < 0) {
       const msg = `No current coverage info found!\nSee ${link} for configuration info.`
-      return utils.maybePostComment(this.config, this.vcs, msg)
+      return utils.maybePostComment(this.config, this.vcs, msg, true)
         .then(() => {
           return Promise.reject(msg)
         })
@@ -152,7 +152,7 @@ class Bumper {
       const diffStr = (base - pct).toFixed(2)
       const baseStr = base.toFixed(2)
       const pctStr = pct.toFixed(2)
-      const msg = `Coverage dropped ${diffStr}% (from ${baseStr}% to ${pctStr}%) in this PR!`
+      const msg = `Code Coverage: \`${pctStr}%\` (dropped \`${diffStr}%\` from \`${baseStr}%\`)`
       return utils.maybePostComment(this.config, this.vcs, msg)
         .then(() => {
           return Promise.reject(msg)
@@ -160,7 +160,7 @@ class Bumper {
     }
 
     const msg = this._getCoverageMsg(base, pct)
-    logger.log(msg)
+    logger.log(msg, true)
     return utils.maybePostComment(this.config, this.vcs, msg)
   }
 
@@ -177,9 +177,9 @@ class Bumper {
     const baseStr = base.toFixed(2)
     if (pct > base) {
       const diffStr = (pct - base).toFixed(2)
-      return `Coverage increased ${diffStr}% (from ${baseStr}% to ${pctStr}%) in this PR! Good job :)`
+      return `Code Coverage: \`${pctStr}%\` (increased \`${diffStr}%\` from \`${baseStr}%\`)`
     } else {
-      return `Coverage remained the same (at ${baseStr}%) in this PR.`
+      return `Code Coverage: \`${baseStr}%\` (no change)`
     }
   }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,18 +6,19 @@ const logger = {
   /**
    * Simple wrapper around console.log() to make it easy to mock it out in tests
    * @param {String} msg - the message to log
+   * @param {Boolean} [force] - when true, log message even if VERBOSE is not set
    */
-  log (msg) {
-    // TODO: check a VERBOSE env var
-    console.log(`${pkgJson.name}: ${msg}`)
+  log (msg, force) {
+    if (force || process.env['VERBOSE']) {
+      console.log(`${pkgJson.name}: ${msg}`)
+    }
   },
 
   /**
-   * Simple wrapper around console.log() to make it easy to mock it out in tests
+   * Simple wrapper around console.error() to make it easy to mock it out in tests
    * @param {String} msg - the message to log
    */
   error (msg) {
-    // TODO: ignore a VERBOSE env var
     console.error(`${pkgJson.name}: ${msg}`)
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,11 +58,16 @@ function getChangelogSectionIndex (lines) {
 /**
  * Get the given key from process.env, substituting "undefined" for the real undefined
  * @param {String} key - the environment variable we want to get
+ * @param {*} defaultValue - value to return if key not in env, or if it is 'undefined'
  * @returns {*} whatever is at process.env[key] with the one exception of "undefined" being translated to undefined
  */
-function getEnv (key) {
-  const value = process.env[key]
-  return (value === 'undefined') ? undefined : value
+function getEnv (key, defaultValue) {
+  let value = process.env[key]
+  if (value === 'undefined') {
+    value = undefined
+  }
+
+  return (value === undefined) ? defaultValue : value
 }
 
 /**
@@ -72,9 +77,9 @@ function getEnv (key) {
 function processEnv (config) {
   // Grab the CI stuff from env
   config.ci.buildNumber = getEnv(config.ci.env.buildNumber)
-  config.prNumber = getEnv(config.ci.env.pr)
+  config.prNumber = getEnv(config.ci.env.pr, 'false')
   config.isPr = config.prNumber !== 'false'
-  config.branch = getEnv(config.ci.env.branch) || 'master'
+  config.branch = getEnv(config.ci.env.branch, 'master')
 
   logger.log(`pr-bumper::config: prNumber [${config.prNumber}], isPr [${config.isPr}]`)
 
@@ -219,9 +224,12 @@ const utils = {
    */
   getScopeForPr (pr) {
     const matches = pr.description.match(/#[A-Za-z]+#/g)
+    const prLink = `[PR #${pr.number}](${pr.url})`
 
     if (!matches) {
-      throw new Error(`No version-bump scope found for PR #${pr.number} (${pr.url})`)
+      const example = 'Please include a scope (i.e. `#major`, `#minor#`, `#patch#`) in your PR description.'
+      const exampleLink = 'See https://github.com/ciena-blueplanet/pr-bumper#pull-requests for more details.'
+      throw new Error(`No version-bump scope found for ${prLink}\n${example}\n${exampleLink}`)
     }
 
     let scope
@@ -237,7 +245,7 @@ const utils = {
       }
 
       if (selectedScopes.length !== 1) {
-        throw new Error(`Too many version-bump scopes found for PR #${pr.number} (${pr.url})`)
+        throw new Error(`Too many version-bump scopes found for ${prLink}`)
       }
 
       scope = selectedScopes[0]
@@ -263,8 +271,10 @@ const utils = {
     }
 
     if (changelog.trim() === '') {
+      const link = 'https://github.com/ciena-blueplanet/pr-bumper#changelog'
       const msg = 'No CHANGELOG content found in PR description.\n' +
-        'Please add a "# CHANGELOG" section to your PR description with some content describing your change'
+        'Please add a `# CHANGELOG` section to your PR description with some content describing your change.\n' +
+        `See ${link} for details.`
       throw new Error(msg)
     }
 
@@ -293,13 +303,15 @@ const utils = {
    * @param {Object} config - the bumper config
    * @param {Vcs} vcs - the vcs instance for the bumper
    * @param {String} msg - the message to post
+   * @param {Boolean} isError - if true, prefix the msg with an ##ERROR heading
    * @returns {Promise} a promise resolved when success, rejected on error
    */
-  maybePostComment (config, vcs, msg) {
+  maybePostComment (config, vcs, msg, isError) {
     if (config.isPr && config.prComments) {
-      return vcs.postComment(config.prNumber, msg)
+      const comment = isError ? `##ERROR\n${msg}` : msg
+      return vcs.postComment(config.prNumber, comment)
         .catch((err) => {
-          const newMessage = `Received error: ${err.message} while trying to post PR comment about: ${msg}`
+          const newMessage = `Received error: ${err.message} while trying to post PR comment: ${comment}`
           throw new Error(newMessage)
         })
     }
@@ -320,7 +332,7 @@ const utils = {
       ret = func()
     } catch (e) {
       if (config.isPr && config.prComments) {
-        return vcs.postComment(config.prNumber, e.message)
+        return vcs.postComment(config.prNumber, `##ERROR\n${e.message}`)
           .then(() => {
             throw e
           })

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -80,6 +80,7 @@ describe('Bumper', function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
     sandbox.stub(logger, 'log')
+    sandbox.stub(logger, 'error')
 
     // stub out the top-level 'exec'
     execStub = sandbox.stub()
@@ -184,7 +185,7 @@ describe('Bumper', function () {
       })
 
       it('should maybe post a comment', function () {
-        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg)
+        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg, true)
       })
 
       it('should reject with an error', function () {
@@ -216,7 +217,7 @@ describe('Bumper', function () {
       })
 
       it('should maybe post a comment', function () {
-        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg)
+        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg, true)
       })
 
       it('should reject with an error', function () {
@@ -249,7 +250,7 @@ describe('Bumper', function () {
       })
 
       it('should maybe post a comment', function () {
-        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg)
+        expect(utils.maybePostComment).to.have.been.calledWith(bumper.config, bumper.vcs, errorMsg, true)
       })
 
       it('should reject with an error', function () {
@@ -261,7 +262,7 @@ describe('Bumper', function () {
       beforeEach(function (done) {
         bumper.config.baselineCoverage = 85.93
         sandbox.stub(utils, 'getCurrentCoverage').returns(84.99)
-        errorMsg = 'Coverage dropped 0.94% (from 85.93% to 84.99%) in this PR!'
+        errorMsg = 'Code Coverage: `84.99%` (dropped `0.94%` from `85.93%`)'
 
         bumper.checkCoverage()
           .then((resp) => {
@@ -294,7 +295,7 @@ describe('Bumper', function () {
       beforeEach(function (done) {
         bumper.config.baselineCoverage = 85.93
         sandbox.stub(utils, 'getCurrentCoverage').returns(85.93)
-        msg = 'Coverage remained the same (at 85.93%) in this PR.'
+        msg = 'Code Coverage: `85.93%` (no change)'
 
         bumper.checkCoverage()
           .then((resp) => {
@@ -322,7 +323,7 @@ describe('Bumper', function () {
       })
 
       it('should log a message', function () {
-        expect(logger.log).to.have.been.calledWith(msg)
+        expect(logger.log).to.have.been.calledWith(msg, true)
       })
     })
 
@@ -331,7 +332,7 @@ describe('Bumper', function () {
       beforeEach(function (done) {
         bumper.config.baselineCoverage = 85.93
         sandbox.stub(utils, 'getCurrentCoverage').returns(88.01)
-        msg = 'Coverage increased 2.08% (from 85.93% to 88.01%) in this PR! Good job :)'
+        msg = 'Code Coverage: `88.01%` (increased `2.08%` from `85.93%`)'
 
         bumper.checkCoverage()
           .then((resp) => {
@@ -359,7 +360,7 @@ describe('Bumper', function () {
       })
 
       it('should log a message', function () {
-        expect(logger.log).to.have.been.calledWith(msg)
+        expect(logger.log).to.have.been.calledWith(msg, true)
       })
     })
   })

--- a/tests/logger-spec.js
+++ b/tests/logger-spec.js
@@ -6,26 +6,96 @@ const sinonChai = require('sinon-chai')
 const expect = chai.expect
 chai.use(sinonChai)
 
-const pkgJson = require('../package.json')
+const name = require('../package.json').name
 const logger = require('../lib/logger')
 
 describe('logger', function () {
-  let stub
-  describe('.log()', function () {
-    it('should log to console', function () {
-      stub = sinon.stub(console, 'log')
-      logger.log('foo bar baz')
-      expect(console.log).to.have.been.calledWith(`${pkgJson.name}: foo bar baz`)
+  let stub, realVerbose
+
+  beforeEach(function () {
+    realVerbose = process.env['VERBOSE']
+  })
+
+  afterEach(function () {
+    process.env['VERBOSE'] = realVerbose
+    if (stub) {
       stub.restore()
+    }
+  })
+
+  describe('.log()', function () {
+    describe('when VERBOSE is not in env', function () {
+      beforeEach(function () {
+        delete process.env['VERBOSE']
+      })
+
+      describe('when force is not given', function () {
+        // NOTE: we do not want to stub console.log in beforeEach b/c it messes with mocha's reporting
+
+        it('should not log to console', function () {
+          stub = sinon.stub(console, 'log')
+          logger.log('foo bar baz')
+          expect(console.log).to.have.callCount(0)
+        })
+      })
+
+      describe('when force is given', function () {
+        it('should log to console', function () {
+          stub = sinon.stub(console, 'log')
+          logger.log('foo bar baz', true)
+          expect(console.log).to.have.been.calledWith(`${name}: foo bar baz`)
+        })
+      })
+    })
+
+    describe('when VERBOSE is in env', function () {
+      beforeEach(function () {
+        process.env['VERBOSE'] = '1'
+      })
+
+      describe('when force is not given', function () {
+        // NOTE: we do not want to stub console.log in beforeEach b/c it messes with mocha's reporting
+
+        it('should log to console', function () {
+          stub = sinon.stub(console, 'log')
+          logger.log('foo bar baz')
+          expect(console.log).to.have.been.calledWith(`${name}: foo bar baz`)
+        })
+      })
+
+      describe('when force is given', function () {
+        it('should log to console', function () {
+          stub = sinon.stub(console, 'log')
+          logger.log('foo bar baz', true)
+          expect(console.log).to.have.been.calledWith(`${name}: foo bar baz`)
+        })
+      })
     })
   })
 
   describe('.error()', function () {
-    it('should log to console', function () {
-      stub = sinon.stub(console, 'error')
-      logger.error('foo bar baz')
-      expect(console.error).to.have.been.calledWith(`${pkgJson.name}: foo bar baz`)
-      stub.restore()
+    describe('when VERBOSE is not in the env', function () {
+      beforeEach(function () {
+        delete process.env['VERBOSE']
+      })
+
+      it('should log to console', function () {
+        stub = sinon.stub(console, 'error')
+        logger.error('foo bar baz')
+        expect(console.error).to.have.been.calledWith(`${name}: foo bar baz`)
+      })
+    })
+
+    describe('when VERBOSE is in the env', function () {
+      beforeEach(function () {
+        process.env['VERBOSE'] = '1'
+      })
+
+      it('should log to console', function () {
+        stub = sinon.stub(console, 'error')
+        logger.error('foo bar baz')
+        expect(console.error).to.have.been.calledWith(`${name}: foo bar baz`)
+      })
     })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** bug where `pr-bumper check-coverage` failed in dev if `prComments` was `true`
* **Fixed** logging in `pr-bumper` to only print if `VERBOSE` environment variable is set (except for coverage info, that is forced to log regardless)
* **Fixed** PR comments to include clear indication if the message is the result of an error.
* **Fixed** PR comments to be formatted nicer (using markdown syntax)
* **Fixed** PR comments to be more detailed and offer a clearer path to know how to resolve the issue at hand. 
* **Added** more documentation about the changelog feature
