### PR TITLE
Fix markdown in pr comments

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -303,12 +303,12 @@ const utils = {
    * @param {Object} config - the bumper config
    * @param {Vcs} vcs - the vcs instance for the bumper
    * @param {String} msg - the message to post
-   * @param {Boolean} isError - if true, prefix the msg with an ##ERROR heading
+   * @param {Boolean} isError - if true, prefix the msg with an ## ERROR heading
    * @returns {Promise} a promise resolved when success, rejected on error
    */
   maybePostComment (config, vcs, msg, isError) {
     if (config.isPr && config.prComments) {
-      const comment = isError ? `##ERROR\n${msg}` : msg
+      const comment = isError ? `## ERROR\n${msg}` : msg
       return vcs.postComment(config.prNumber, comment)
         .catch((err) => {
           const newMessage = `Received error: ${err.message} while trying to post PR comment: ${comment}`
@@ -332,7 +332,7 @@ const utils = {
       ret = func()
     } catch (e) {
       if (config.isPr && config.prComments) {
-        return vcs.postComment(config.prNumber, `##ERROR\n${e.message}`)
+        return vcs.postComment(config.prNumber, `## ERROR\n${e.message}`)
           .then(() => {
             throw e
           })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1106,7 +1106,7 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
 
       it('should post a comment', function () {
-        expect(vcs.postComment).to.have.been.calledWith(config.prNumber, '##ERROR\nfizz-bang')
+        expect(vcs.postComment).to.have.been.calledWith(config.prNumber, '## ERROR\nfizz-bang')
       })
 
       it('should not reject yet', function () {
@@ -1141,7 +1141,7 @@ Thought this might be #breaking# but on second thought it is a minor change
         })
 
         it('should reject with a combined error', function () {
-          const msg = 'Received error: Aw snap! while trying to post PR comment: ##ERROR\nfizz-bang'
+          const msg = 'Received error: Aw snap! while trying to post PR comment: ## ERROR\nfizz-bang'
           expect(error.message).to.equal(msg)
         })
 
@@ -1291,7 +1291,7 @@ Thought this might be #breaking# but on second thought it is a minor change
         })
 
         it('should post a comment', function () {
-          expect(vcs.postComment).to.have.been.calledWith(config.prNumber, '##ERROR\nUh oh!')
+          expect(vcs.postComment).to.have.been.calledWith(config.prNumber, '## ERROR\nUh oh!')
         })
 
         it('should not reject yet', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** PR comments to use `## ERROR` instead of `##ERROR` since apparently at least bitbucket doesn't consider the latter a heading. 
