### PR TITLE
Add ability to skip comments in check-coverage

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -307,7 +307,7 @@ const utils = {
    * @returns {Promise} a promise resolved when success, rejected on error
    */
   maybePostComment (config, vcs, msg, isError) {
-    if (config.isPr && config.prComments) {
+    if (!process.env['SKIP_COMMENTS'] && config.isPr && config.prComments) {
       const comment = isError ? `## ERROR\n${msg}` : msg
       return vcs.postComment(config.prNumber, comment)
         .catch((err) => {

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1031,6 +1031,47 @@ Thought this might be #breaking# but on second thought it is a minor change
       })
     })
 
+    describe('when prComments is true, and isPr is true, but SKIP_COMMENTS is in env', function () {
+      let realSkipComments
+      beforeEach(function (done) {
+        realSkipComments = process.env['SKIP_COMMENTS']
+        process.env['SKIP_COMMENTS'] = '1'
+        config.isPr = true
+        config.prComments = true
+        utils.maybePostComment(config, vcs, 'fizz-bang')
+          .then((resp) => {
+            result = resp
+          })
+          .catch((err) => {
+            error = err
+          })
+
+        setTimeout(() => {
+          done()
+        }, 0)
+      })
+
+      afterEach(function () {
+        if (realSkipComments !== undefined) {
+          process.env['SKIP_COMMENTS'] = realSkipComments
+        } else {
+          delete process.env['SKIP_COMMENTS']
+        }
+      })
+
+      it('should not post a comment', function () {
+        expect(vcs.postComment).to.have.callCount(0)
+      })
+
+      it('should not reject', function () {
+        expect(error).to.equal(null)
+      })
+
+      it('should resolve', function () {
+        expect(result).to.equal(undefined)
+      })
+    })
+
     describe('and prComments is true and isPr is true', function () {
       let promise
       beforeEach(function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** support for skipping pr comments in the `pr-bumper check-coverage` command by supplying a `SKIP_COMMENTS` env variable.