### PR TITLE
Switch to checking statements instead of lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ of `pr-bumper check-coverage` in your CI (after your tests run and coverage is r
 The "current" coverage that `pr-bumper` will compare against this "baseline" will be read from the file at
 `coverage/coverage-summary.json`. This can be populated using the `json-summary` reporter from `istanbul`.
 There are a number of statistics in `coverage-summary.json`, but the one that `pr-bumper` looks at is the total
-percentage of lines covered, or `total.lines.pct`.
+percentage of statements covered, or `total.statements.pct`.
 
 ### Pull Request comments
 > **EXCEPT** on github.com

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,7 +293,7 @@ const utils = {
       coverageSummary = require(path.join(process.cwd(), 'coverage/coverage-summary.json'))
     }
 
-    const pct = __.get(coverageSummary, 'total.lines.pct') || -1
+    const pct = __.get(coverageSummary, 'total.statements.pct') || -1
 
     return pct
   },

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -922,7 +922,7 @@ Thought this might be #breaking# but on second thought it is a minor change
     beforeEach(function () {
       cov = {
         total: {
-          lines: {
+          statements: {
             pct: 95.98
           }
         }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** check for current coverage to use `statements` instead of `lines` as it seems the more accurate metric.