### PR TITLE
Add ability to skip PR comments with CLI option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,10 +10,11 @@ const cli = new Cli()
 
 program
   .version(pkgJson.version)
+  .option('-s, --skip-comments', 'disable PR comments even if enabled via .pr-bumper.json')
   .arguments('<cmd>')
-  .action((cmd, options) => {
+  .action((cmd, program) => {
     cli
-      .run(cmd, options)
+      .run(cmd, program.skipComments)
       .catch((error) => {
         const msg = (error.message) ? error.message : error
         console.log(`${pkgJson.name}: ERROR: ${msg}`)
@@ -24,9 +25,17 @@ program
       })
   })
   .on('--help', () => {
+    console.log('  Options:')
+    console.log('')
+    console.log(
+      '    --skip-comments - disable PR comments even if enabled via .pr-bumper.json\n' +
+      '                      Useful particularly when running check-coverage manually'
+    )
+    console.log('')
     console.log('  Commands:')
     console.log('')
     console.log('    check - verify an open PR has a version-bump comment')
+    console.log('    check-coverage - compare current code coverage against baseline from package.json')
     console.log('    bump - actually bump the version based on the merged PR')
     console.log('')
   })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -22,11 +22,14 @@ class Cli {
   /**
    * Run the specified command
    * @param {String} cmd - the command to run
-   * @param {String} options - the command line options
+   * @param {Boolean} [skipComments] - true if the command line options specified we need to skip pr comments
    * @returns {Promise} a promise resolved when command finishes, or rejected with failure
    */
-  run (cmd, options) {
+  run (cmd, skipComments) {
     const config = utils.getConfig()
+    if (skipComments) {
+      config.prComments = false
+    }
     const vcs = this._getVcs(config)
     const ci = this._getCi(config, vcs)
     const bumper = this._getBumper({ci, config, vcs})

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,7 +227,7 @@ const utils = {
     const prLink = `[PR #${pr.number}](${pr.url})`
 
     if (!matches) {
-      const example = 'Please include a scope (i.e. `#major`, `#minor#`, `#patch#`) in your PR description.'
+      const example = 'Please include a scope (e.g. `#major#`, `#minor#`, `#patch#`) in your PR description.'
       const exampleLink = 'See https://github.com/ciena-blueplanet/pr-bumper#pull-requests for more details.'
       throw new Error(`No version-bump scope found for ${prLink}\n${example}\n${exampleLink}`)
     }

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -192,6 +192,50 @@ describe('Cli', function () {
       })
     })
 
+    describe('check-coverage --skip-comments', function () {
+      beforeEach(function () {
+        result = ''
+        error = ''
+
+        return cli
+          .run('check-coverage', true)
+          .then((res) => {
+            result = res
+          })
+          .catch((err) => {
+            error = err
+          })
+      })
+
+      it('should get the config', function () {
+        expect(utils.getConfig).to.have.callCount(1)
+      })
+
+      it('should get the vcs', function () {
+        expect(cli._getVcs).to.have.been.calledWith({id: 'config', prComments: false})
+      })
+
+      it('should get the ci', function () {
+        expect(cli._getCi).to.have.been.calledWith({id: 'config', prComments: false}, {id: 'vcs'})
+      })
+
+      it('should get the bumper', function () {
+        expect(cli._getBumper).to.have.been.calledWith({
+          ci: {id: 'ci'},
+          config: {id: 'config', prComments: false},
+          vcs: {id: 'vcs'}
+        })
+      })
+
+      it('should resolve with the result of check', function () {
+        expect(result).to.be.equal('coverage-checked')
+      })
+
+      it('should not error', function () {
+        expect(error).to.equal('')
+      })
+    })
+
     describe('invalid command', function () {
       beforeEach(function () {
         result = ''

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -751,7 +751,7 @@ describe('utils', function () {
           utils.getScopeForPr(pr)
         }
 
-        const example = 'Please include a scope (i.e. `#major`, `#minor#`, `#patch#`) in your PR description.'
+        const example = 'Please include a scope (e.g. `#major#`, `#minor#`, `#patch#`) in your PR description.'
         const exampleLink = 'See https://github.com/ciena-blueplanet/pr-bumper#pull-requests for more details.'
         expect(fn).to.throw(`No version-bump scope found for [PR #12345](my-pr-url)\n${example}\n${exampleLink}`)
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** a command-line switch `--skip-comments` which explicitly sets `prComments` to `false` in the config, regardless of what is in `.pr-bumper.json`. Useful when you just want to get the coverage change info and setting `SKIP_COMMENTS` environment variable is difficult. 

* **Fixed** grammar of PR comment about missing scope (thanks @gknoy)
