### PR TITLE
Fix maybe-install to fail if install fails

### DIFF
--- a/.travis/maybe-install.sh
+++ b/.travis/maybe-install.sh
@@ -16,6 +16,13 @@ else
   npm install
 fi
 
+# If the install fails, make sure to fail the whole script
+ret=$?
+if [ $ret ]
+then
+  exit $ret
+fi
+
 # If bower configuration and bower command are present install bower dependencies
 if [ -f bower.json ]
 then


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** a bug in `.travis/maybe-install.sh` where the `npm install` or `yarn install` could fail and the script would still pass. 
