### PR TITLE
Adding safeUrl to bitbucket error messages

### DIFF
--- a/lib/vcs/bitbucket.js
+++ b/lib/vcs/bitbucket.js
@@ -69,7 +69,7 @@ class Bitbucket {
     return fetch(url)
       .then((resp) => {
         if (!resp.ok) {
-          throw new Error(`${resp.status}: ${JSON.stringify(resp.json())}`)
+          throw new Error(`${safeUrl} ${resp.status}: ${JSON.stringify(resp.json())}`)
         }
         return resp.json()
       })
@@ -98,7 +98,7 @@ class Bitbucket {
     })
       .then((resp) => {
         if (!resp.ok) {
-          throw new Error(`${resp.status}: API 1.0 Error`)
+          throw new Error(`${safeUrl} ${resp.status}: API 1.0 Error`)
         }
       })
   }

--- a/tests/vcs/bitbucket-spec.js
+++ b/tests/vcs/bitbucket-spec.js
@@ -155,7 +155,7 @@ describe('VCS / Bitbucket /', function () {
         err = {
           message: 'Uh oh'
         }
-        sandbox.stub(resp, 'json').returns(Promise.resolve(err))
+        sandbox.stub(resp, 'json').returns(err)
 
         promise.catch(() => {
           done()
@@ -169,7 +169,7 @@ describe('VCS / Bitbucket /', function () {
       })
 
       it('should reject with the proper error', function () {
-        expect(rejection).to.be.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.be.eql(new Error(`https://api.bitbucket.org/2.0/repositories/owner/repo/pullrequests/5 400: ${JSON.stringify(err)}`))
       })
     })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
Adding `safeUrl` to bitbucket error messages