### PR TITLE
Fix bug when 0s are in coverage file

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -353,14 +353,14 @@ const utils = {
    */
   getCurrentCoverage (config) {
     const coverageSummary = this.readJsonFile(config.features.coverage.file)
-    const totalStatements = __.get(coverageSummary, 'total.statements.total') || -1
+    const totalStatements = __.get(coverageSummary, 'total.statements.total', -1)
 
     if (totalStatements === -1) {
       return -1
     }
 
     const coveredStatements = __.get(coverageSummary, 'total.statements.covered')
-    const totalBranches = __.get(coverageSummary, 'total.branches.total') || -1
+    const totalBranches = __.get(coverageSummary, 'total.branches.total', -1)
     const coveredBranches = __.get(coverageSummary, 'total.branches.covered')
 
     const pct = (coveredStatements + coveredBranches) / (totalStatements + totalBranches) * 100

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1198,6 +1198,28 @@ Thought this might be #breaking# but on second thought it is a minor change
         expect(pct).to.equal(89.00)
       })
     })
+
+    describe('when coverage is present (but no branches)', function () {
+      beforeEach(function () {
+        utils.readJsonFile.withArgs('path-to-coverage/coverage-file.json').returns({
+          total: {
+            branches: {
+              total: 0,
+              covered: 0
+            },
+            statements: {
+              total: 100,
+              covered: 80
+            }
+          }
+        })
+        pct = utils.getCurrentCoverage(config)
+      })
+
+      it('should return the total statement and branch pct', function () {
+        expect(pct).to.equal(80.00)
+      })
+    })
   })
 
   describe('.maybePostComment()', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** edge case bug where coverage info includes a `0`. 