### PR TITLE
Alter CHANGELOG.md to address my mistake of side-stepping the pr-bumper workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.2.3 (2018-01-19)
-* **Fixed** edge case bug where coverage info includes a `0`. 
+* Updated README.md to remove `@^2.0.0` from NPM intallation instructions 
 
 # 3.2.2 (2017-12-11)
 * **Fixed** edge case bug where coverage info includes a `0`. 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

I messed up by editing the _README.md_ file directly on the GitHub site rather than submitting a PR.  This then caused `v3.2.3` to be released with an incorrect entry in the _CHANGELOG.md_ file.  This PR alters the entry to clean up my mess.

# CHANGELOG
* Update prior entry in _CHANGELOG.md_ file