### PR TITLE
Update pre-release version increment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ then `pr-bumper` will be able to do a `patch` bump to increment the last number 
 | 1.2.3            | `#none#`                  | 1.2.3          |
 | 1.2.3-alpha.4    | `#none#`                  | 1.2.3-alpha.4  |
 | 1.2.3            | `#patch#` or `#fix#`      | 1.2.4          |
-| 1.2.3-alpha.4    | `#patch#` or `#fix#`      | 1.2.4-alpha.5  |
-| 1.2.3-a.b.9      | `#patch#` or `#fix#`      | 1.2.4-a.b.10   |
+| 1.2.3-alpha.4    | `#patch#` or `#fix#`      | 1.2.3-alpha.5  |
+| 1.2.3-a.b.9      | `#patch#` or `#fix#`      | 1.2.3-a.b.10   |
 | 1.2.3            | `#minor#` or `#feature#`  | 1.3.0          |
 | 1.2.3-alpha.4    | `#minor#` or `#feature#`  | 1.3.0          |
 | 1.2.3            | `#major#` or `#breaking#` | 2.0.0          |


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Per https://github.com/ciena-blueplanet/pr-bumper/blob/076fdbf97b2f04371a1c49bb11d9451eb864a5c7/lib/bumper.js#L45 and https://github.com/ciena-blueplanet/versiony#prerelease

> Causes the last section of the dot-delimited pre-release tag to be incremented by 1 (e.g. `1.2.3-beta.3` becomes `1.2.3-beta.4`)

the version listed in the example is incorrect.

# CHANGELOG
* Update pre-release version increment example