### PR TITLE
Allow multiple spaces after bullet in GFM checkbox markdown

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -296,7 +296,7 @@ const utils = {
 
     if (matches.length > 1) {
       // check for GFM checkboxes
-      const gfmCheckbockRegex = /-\s\[x\].*?#(\w+)#/gi
+      const gfmCheckbockRegex = /-\s+\[x\].*?#(\w+)#/gi
 
       let selectedScopes = []
       let checkboxMatches

--- a/tests/compliance/dependencies-spec.js
+++ b/tests/compliance/dependencies-spec.js
@@ -124,8 +124,8 @@ describe('dependencies', function () {
         licenseSources = {
           package: {
             sources: [
-              { license: 'MIT' },
-              { license: 'Apache' }
+              {license: 'MIT'},
+              {license: 'Apache'}
             ]
           }
         }
@@ -146,9 +146,9 @@ describe('dependencies', function () {
           },
           license: {
             sources: [
-              { text: 'MIT' },
-              { text: 'Apache' },
-              { text: 'blargh' }
+              {text: 'MIT'},
+              {text: 'Apache'},
+              {text: 'blargh'}
             ]
           }
         }
@@ -185,9 +185,9 @@ describe('dependencies', function () {
             },
             license: {
               sources: [
-                { text: 'MIT' },
-                { text: 'Apache' },
-                { text: 'blargh' }
+                {text: 'MIT'},
+                {text: 'Apache'},
+                {text: 'blargh'}
               ]
             }
           }

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1011,67 +1011,136 @@ describe('utils', function () {
       })
     })
 
-    describe('when GFM checkbox syntax is present with one scope checked', function () {
-      beforeEach(function () {
-        pr.description = `
-### Check the scope of this pr:
-- [ ] #none# - documentation fixes and/or test additions
-- [ ] #patch# - bugfix, dependency update
-- [x] #minor# - new feature, backwards compatible
-- [ ] #major# - major feature, probably breaking API
-- [ ] #breaking# - any change that breaks the API`
-        scope = utils.getScopeForPr(pr)
+    describe('when GFM checkbox syntax is present with single space in bullets', function () {
+      describe('when one scope checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  - [ ] #none# - documentation fixes and/or test additions
+  - [ ] #patch# - bugfix, dependency update
+  - [x] #minor# - new feature, backwards compatible
+  - [ ] #major# - major feature, probably breaking API
+  - [ ] #breaking# - any change that breaks the API`
+          scope = utils.getScopeForPr(pr)
+        })
+
+        it('should call .getValidatedScope() with proper arguments', function () {
+          expect(utils.getValidatedScope).to.have.been.calledWith({
+            scope: 'minor',
+            maxScope: 'major',
+            prNumber: '12345',
+            prUrl: 'my-pr-url'
+          })
+        })
       })
 
-      it('should call .getValidatedScope() with proper arguments', function () {
-        expect(utils.getValidatedScope).to.have.been.calledWith({
-          scope: 'minor',
-          maxScope: 'major',
-          prNumber: '12345',
-          prUrl: 'my-pr-url'
+      describe('when multiple scopes checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  - [x] #patch# - bugfix, dependency update
+  - [ ] #minor# - new feature, backwards compatible
+  - [x] #major# - major feature, probably breaking API
+  - [ ] #breaking# - any change that breaks the API`
+        })
+
+        it('should throw an error', function () {
+          const fn = () => {
+            utils.getScopeForPr(pr)
+          }
+
+          expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+        })
+      })
+
+      describe('when one scope checked and other scopes mentioned', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  - [ ] #patch# - bugfix, dependency update
+  - [x] #minor# - new feature, backwards compatible
+  - [ ] #major# - major feature, probably breaking API
+  - [ ] #breaking# - any change that breaks the API
+
+  Thought this might be #breaking# but on second thought it is a minor change
+  `
+          scope = utils.getScopeForPr(pr)
+        })
+
+        it('should call .getValidatedScope() with proper arguments', function () {
+          expect(utils.getValidatedScope).to.have.been.calledWith({
+            scope: 'minor',
+            maxScope: 'major',
+            prNumber: '12345',
+            prUrl: 'my-pr-url'
+          })
         })
       })
     })
 
-    describe('when GFM checkbox syntax is present with multiple scopes checked', function () {
-      beforeEach(function () {
-        pr.description = `
-### Check the scope of this pr:
-- [x] #patch# - bugfix, dependency update
-- [ ] #minor# - new feature, backwards compatible
-- [x] #major# - major feature, probably breaking API
-- [ ] #breaking# - any change that breaks the API`
+    describe('when GFM checkbox syntax is present with multiple spaces in bullets', function () {
+      describe('when one scope checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  -  [ ] #none# - documentation fixes and/or test additions
+  -  [ ] #patch# - bugfix, dependency update
+  -  [x] #minor# - new feature, backwards compatible
+  -  [ ] #major# - major feature, probably breaking API
+  -  [ ] #breaking# - any change that breaks the API`
+          scope = utils.getScopeForPr(pr)
+        })
+
+        it('should call .getValidatedScope() with proper arguments', function () {
+          expect(utils.getValidatedScope).to.have.been.calledWith({
+            scope: 'minor',
+            maxScope: 'major',
+            prNumber: '12345',
+            prUrl: 'my-pr-url'
+          })
+        })
       })
 
-      it('should throw an error', function () {
-        const fn = () => {
-          utils.getScopeForPr(pr)
-        }
+      describe('when multiple scopes checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  -  [x] #patch# - bugfix, dependency update
+  -  [ ] #minor# - new feature, backwards compatible
+  -  [x] #major# - major feature, probably breaking API
+  -  [ ] #breaking# - any change that breaks the API`
+        })
 
-        expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
-      })
-    })
+        it('should throw an error', function () {
+          const fn = () => {
+            utils.getScopeForPr(pr)
+          }
 
-    describe('when GFM checkbox syntax is present with one scope checked and other scopes mentioned', function () {
-      beforeEach(function () {
-        pr.description = `
-### Check the scope of this pr:
-- [ ] #patch# - bugfix, dependency update
-- [x] #minor# - new feature, backwards compatible
-- [ ] #major# - major feature, probably breaking API
-- [ ] #breaking# - any change that breaks the API
-
-Thought this might be #breaking# but on second thought it is a minor change
-`
-        scope = utils.getScopeForPr(pr)
+          expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+        })
       })
 
-      it('should call .getValidatedScope() with proper arguments', function () {
-        expect(utils.getValidatedScope).to.have.been.calledWith({
-          scope: 'minor',
-          maxScope: 'major',
-          prNumber: '12345',
-          prUrl: 'my-pr-url'
+      describe('when one scope checked and other scopes mentioned', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  -  [ ] #patch# - bugfix, dependency update
+  -  [x] #minor# - new feature, backwards compatible
+  -  [ ] #major# - major feature, probably breaking API
+  -  [ ] #breaking# - any change that breaks the API
+
+  Thought this might be #breaking# but on second thought it is a minor change
+  `
+          scope = utils.getScopeForPr(pr)
+        })
+
+        it('should call .getValidatedScope() with proper arguments', function () {
+          expect(utils.getValidatedScope).to.have.been.calledWith({
+            scope: 'minor',
+            maxScope: 'major',
+            prNumber: '12345',
+            prUrl: 'my-pr-url'
+          })
         })
       })
     })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** ability to specify multiple spaces after bullets in GFM markdown, as some markdown lint standards prefer to have a couple spaces between bullets and the list content rather than just a single space.
* **Fixed** lint warnings.
