### PR TITLE
Improve error message for when no gfm checkboxes are checked

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,9 @@ const __ = require('lodash')
 
 const logger = require('./logger')
 
+const GFM_CHECKBOX_CHECKED_REGEX = /-\s+\[x\].*?#(\w+)#/gi
+const GFM_CHECKBOX_UNCHECKED_REGEX = /-\s+\[\s\].*?#(\w+)#/gi
+
 /**
  * Walk the properties of an object (recursively) while converting it to a flat representation of the leaves of the
  * object (properties with primitive, non-object types which need their default value set).
@@ -69,6 +72,20 @@ function getEnv (key, defaultValue) {
   }
 
   return (value === undefined) ? defaultValue : value
+}
+
+function throwIfInvalidScope (matches, prDescription, prLink, selectedScopes) {
+  if (selectedScopes.length === 0) {
+    const gfmCheckboxMatches = prDescription.match(GFM_CHECKBOX_UNCHECKED_REGEX)
+
+    if (Array.isArray(gfmCheckboxMatches) && matches.length === gfmCheckboxMatches.length) {
+      throw new Error(`No version-bump scope found for ${prLink}`)
+    }
+  }
+
+  if (selectedScopes.length !== 1) {
+    throw new Error(`Too many version-bump scopes found for ${prLink}`)
+  }
 }
 
 /**
@@ -295,18 +312,13 @@ const utils = {
     let scope
 
     if (matches.length > 1) {
-      // check for GFM checkboxes
-      const gfmCheckbockRegex = /-\s+\[x\].*?#(\w+)#/gi
-
       let selectedScopes = []
       let checkboxMatches
-      while ((checkboxMatches = gfmCheckbockRegex.exec(pr.description)) !== null) {
+      while ((checkboxMatches = GFM_CHECKBOX_CHECKED_REGEX.exec(pr.description)) !== null) {
         selectedScopes.push(checkboxMatches[1])
       }
 
-      if (selectedScopes.length !== 1) {
-        throw new Error(`Too many version-bump scopes found for ${prLink}`)
-      }
+      throwIfInvalidScope(matches, pr.description, prLink, selectedScopes)
 
       scope = selectedScopes[0]
     } else {

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1012,6 +1012,26 @@ describe('utils', function () {
     })
 
     describe('when GFM checkbox syntax is present with single space in bullets', function () {
+      describe('when no scope checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  - [ ] #none# - documentation fixes and/or test additions
+  - [ ] #patch# - bugfix, dependency update
+  - [ ] #minor# - new feature, backwards compatible
+  - [ ] #major# - major feature, probably breaking API
+  - [ ] #breaking# - any change that breaks the API`
+        })
+
+        it('should throw an error', function () {
+          const fn = () => {
+            utils.getScopeForPr(pr)
+          }
+
+          expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+        })
+      })
+
       describe('when one scope checked', function () {
         beforeEach(function () {
           pr.description = `
@@ -1079,6 +1099,26 @@ describe('utils', function () {
     })
 
     describe('when GFM checkbox syntax is present with multiple spaces in bullets', function () {
+      describe('when no scope checked', function () {
+        beforeEach(function () {
+          pr.description = `
+  ### Check the scope of this pr:
+  -  [ ] #none# - documentation fixes and/or test additions
+  -  [ ] #patch# - bugfix, dependency update
+  -  [ ] #minor# - new feature, backwards compatible
+  -  [ ] #major# - major feature, probably breaking API
+  -  [ ] #breaking# - any change that breaks the API`
+        })
+
+        it('should throw an error', function () {
+          const fn = () => {
+            utils.getScopeForPr(pr)
+          }
+
+          expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+        })
+      })
+
       describe('when one scope checked', function () {
         beforeEach(function () {
           pr.description = `


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** error message for when no GFM checkboxes are checked to say `No version-bump scope found` instead of `Too many version-bump scopes found`.
