### PR TITLE
Allow asterisks for bullets in GFM

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,8 +10,8 @@ const __ = require('lodash')
 
 const logger = require('./logger')
 
-const GFM_CHECKBOX_CHECKED_REGEX = /-\s+\[x\].*?#(\w+)#/gi
-const GFM_CHECKBOX_UNCHECKED_REGEX = /-\s+\[\s\].*?#(\w+)#/gi
+const GFM_CHECKBOX_CHECKED_REGEX = /(-|\*)\s+\[x\].*?#(\w+)#/gi
+const GFM_CHECKBOX_UNCHECKED_REGEX = /(-|\*)\s+\[\s\].*?#(\w+)#/gi
 
 /**
  * Walk the properties of an object (recursively) while converting it to a flat representation of the leaves of the
@@ -315,7 +315,7 @@ const utils = {
       let selectedScopes = []
       let checkboxMatches
       while ((checkboxMatches = GFM_CHECKBOX_CHECKED_REGEX.exec(pr.description)) !== null) {
-        selectedScopes.push(checkboxMatches[1])
+        selectedScopes.push(checkboxMatches[2])
       }
 
       throwIfInvalidScope(matches, pr.description, prLink, selectedScopes)

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1011,175 +1011,353 @@ describe('utils', function () {
       })
     })
 
-    describe('when GFM checkbox syntax is present with single space in bullets', function () {
-      describe('when no scope checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  - [ ] #none# - documentation fixes and/or test additions
-  - [ ] #patch# - bugfix, dependency update
-  - [ ] #minor# - new feature, backwards compatible
-  - [ ] #major# - major feature, probably breaking API
-  - [ ] #breaking# - any change that breaks the API`
+    describe('when GFM checkbox syntax is present with hyphen bullets', function () {
+      describe('when single space in bullets', function () {
+        describe('when no scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    - [ ] #none# - documentation fixes and/or test additions
+    - [ ] #patch# - bugfix, dependency update
+    - [ ] #minor# - new feature, backwards compatible
+    - [ ] #major# - major feature, probably breaking API
+    - [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should throw an error', function () {
-          const fn = () => {
-            utils.getScopeForPr(pr)
-          }
+        describe('when one scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    - [ ] #none# - documentation fixes and/or test additions
+    - [ ] #patch# - bugfix, dependency update
+    - [x] #minor# - new feature, backwards compatible
+    - [ ] #major# - major feature, probably breaking API
+    - [ ] #breaking# - any change that breaks the API`
+            scope = utils.getScopeForPr(pr)
+          })
 
-          expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
+          })
         })
-      })
 
-      describe('when one scope checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  - [ ] #none# - documentation fixes and/or test additions
-  - [ ] #patch# - bugfix, dependency update
-  - [x] #minor# - new feature, backwards compatible
-  - [ ] #major# - major feature, probably breaking API
-  - [ ] #breaking# - any change that breaks the API`
-          scope = utils.getScopeForPr(pr)
+        describe('when multiple scopes checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    - [x] #patch# - bugfix, dependency update
+    - [ ] #minor# - new feature, backwards compatible
+    - [x] #major# - major feature, probably breaking API
+    - [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should call .getValidatedScope() with proper arguments', function () {
-          expect(utils.getValidatedScope).to.have.been.calledWith({
-            scope: 'minor',
-            maxScope: 'major',
-            prNumber: '12345',
-            prUrl: 'my-pr-url'
+        describe('when one scope checked and other scopes mentioned', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    - [ ] #patch# - bugfix, dependency update
+    - [x] #minor# - new feature, backwards compatible
+    - [ ] #major# - major feature, probably breaking API
+    - [ ] #breaking# - any change that breaks the API
+
+    Thought this might be #breaking# but on second thought it is a minor change
+    `
+            scope = utils.getScopeForPr(pr)
+          })
+
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
           })
         })
       })
 
-      describe('when multiple scopes checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  - [x] #patch# - bugfix, dependency update
-  - [ ] #minor# - new feature, backwards compatible
-  - [x] #major# - major feature, probably breaking API
-  - [ ] #breaking# - any change that breaks the API`
+      describe('when multiple spaces in bullets', function () {
+        describe('when no scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    -  [ ] #none# - documentation fixes and/or test additions
+    -  [ ] #patch# - bugfix, dependency update
+    -  [ ] #minor# - new feature, backwards compatible
+    -  [ ] #major# - major feature, probably breaking API
+    -  [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should throw an error', function () {
-          const fn = () => {
-            utils.getScopeForPr(pr)
-          }
+        describe('when one scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    -  [ ] #none# - documentation fixes and/or test additions
+    -  [ ] #patch# - bugfix, dependency update
+    -  [x] #minor# - new feature, backwards compatible
+    -  [ ] #major# - major feature, probably breaking API
+    -  [ ] #breaking# - any change that breaks the API`
+            scope = utils.getScopeForPr(pr)
+          })
 
-          expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
+          })
         })
-      })
 
-      describe('when one scope checked and other scopes mentioned', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  - [ ] #patch# - bugfix, dependency update
-  - [x] #minor# - new feature, backwards compatible
-  - [ ] #major# - major feature, probably breaking API
-  - [ ] #breaking# - any change that breaks the API
+        describe('when multiple scopes checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    -  [x] #patch# - bugfix, dependency update
+    -  [ ] #minor# - new feature, backwards compatible
+    -  [x] #major# - major feature, probably breaking API
+    -  [ ] #breaking# - any change that breaks the API`
+          })
 
-  Thought this might be #breaking# but on second thought it is a minor change
-  `
-          scope = utils.getScopeForPr(pr)
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should call .getValidatedScope() with proper arguments', function () {
-          expect(utils.getValidatedScope).to.have.been.calledWith({
-            scope: 'minor',
-            maxScope: 'major',
-            prNumber: '12345',
-            prUrl: 'my-pr-url'
+        describe('when one scope checked and other scopes mentioned', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    -  [ ] #patch# - bugfix, dependency update
+    -  [x] #minor# - new feature, backwards compatible
+    -  [ ] #major# - major feature, probably breaking API
+    -  [ ] #breaking# - any change that breaks the API
+
+    Thought this might be #breaking# but on second thought it is a minor change
+    `
+            scope = utils.getScopeForPr(pr)
+          })
+
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
           })
         })
       })
     })
 
-    describe('when GFM checkbox syntax is present with multiple spaces in bullets', function () {
-      describe('when no scope checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  -  [ ] #none# - documentation fixes and/or test additions
-  -  [ ] #patch# - bugfix, dependency update
-  -  [ ] #minor# - new feature, backwards compatible
-  -  [ ] #major# - major feature, probably breaking API
-  -  [ ] #breaking# - any change that breaks the API`
+    describe('when GFM checkbox syntax is present with asterisk bullets', function () {
+      describe('when single space in bullets', function () {
+        describe('when no scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    * [ ] #none# - documentation fixes and/or test additions
+    * [ ] #patch# - bugfix, dependency update
+    * [ ] #minor# - new feature, backwards compatible
+    * [ ] #major# - major feature, probably breaking API
+    * [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should throw an error', function () {
-          const fn = () => {
-            utils.getScopeForPr(pr)
-          }
+        describe('when one scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    * [ ] #none# - documentation fixes and/or test additions
+    * [ ] #patch# - bugfix, dependency update
+    * [x] #minor# - new feature, backwards compatible
+    * [ ] #major# - major feature, probably breaking API
+    * [ ] #breaking# - any change that breaks the API`
+            scope = utils.getScopeForPr(pr)
+          })
 
-          expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
+          })
         })
-      })
 
-      describe('when one scope checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  -  [ ] #none# - documentation fixes and/or test additions
-  -  [ ] #patch# - bugfix, dependency update
-  -  [x] #minor# - new feature, backwards compatible
-  -  [ ] #major# - major feature, probably breaking API
-  -  [ ] #breaking# - any change that breaks the API`
-          scope = utils.getScopeForPr(pr)
+        describe('when multiple scopes checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    * [x] #patch# - bugfix, dependency update
+    * [ ] #minor# - new feature, backwards compatible
+    * [x] #major# - major feature, probably breaking API
+    * [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should call .getValidatedScope() with proper arguments', function () {
-          expect(utils.getValidatedScope).to.have.been.calledWith({
-            scope: 'minor',
-            maxScope: 'major',
-            prNumber: '12345',
-            prUrl: 'my-pr-url'
+        describe('when one scope checked and other scopes mentioned', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    * [ ] #patch# - bugfix, dependency update
+    * [x] #minor# - new feature, backwards compatible
+    * [ ] #major# - major feature, probably breaking API
+    * [ ] #breaking# - any change that breaks the API
+
+    Thought this might be #breaking# but on second thought it is a minor change
+    `
+            scope = utils.getScopeForPr(pr)
+          })
+
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
           })
         })
       })
 
-      describe('when multiple scopes checked', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  -  [x] #patch# - bugfix, dependency update
-  -  [ ] #minor# - new feature, backwards compatible
-  -  [x] #major# - major feature, probably breaking API
-  -  [ ] #breaking# - any change that breaks the API`
+      describe('when multiple spaces in bullets', function () {
+        describe('when no scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    *  [ ] #none# - documentation fixes and/or test additions
+    *  [ ] #patch# - bugfix, dependency update
+    *  [ ] #minor# - new feature, backwards compatible
+    *  [ ] #major# - major feature, probably breaking API
+    *  [ ] #breaking# - any change that breaks the API`
+          })
+
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('No version-bump scope found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should throw an error', function () {
-          const fn = () => {
-            utils.getScopeForPr(pr)
-          }
+        describe('when one scope checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    *  [ ] #none# - documentation fixes and/or test additions
+    *  [ ] #patch# - bugfix, dependency update
+    *  [x] #minor# - new feature, backwards compatible
+    *  [ ] #major# - major feature, probably breaking API
+    *  [ ] #breaking# - any change that breaks the API`
+            scope = utils.getScopeForPr(pr)
+          })
 
-          expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
+          })
         })
-      })
 
-      describe('when one scope checked and other scopes mentioned', function () {
-        beforeEach(function () {
-          pr.description = `
-  ### Check the scope of this pr:
-  -  [ ] #patch# - bugfix, dependency update
-  -  [x] #minor# - new feature, backwards compatible
-  -  [ ] #major# - major feature, probably breaking API
-  -  [ ] #breaking# - any change that breaks the API
+        describe('when multiple scopes checked', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    *  [x] #patch# - bugfix, dependency update
+    *  [ ] #minor# - new feature, backwards compatible
+    *  [x] #major# - major feature, probably breaking API
+    *  [ ] #breaking# - any change that breaks the API`
+          })
 
-  Thought this might be #breaking# but on second thought it is a minor change
-  `
-          scope = utils.getScopeForPr(pr)
+          it('should throw an error', function () {
+            const fn = () => {
+              utils.getScopeForPr(pr)
+            }
+
+            expect(fn).to.throw('Too many version-bump scopes found for [PR #12345](my-pr-url)')
+          })
         })
 
-        it('should call .getValidatedScope() with proper arguments', function () {
-          expect(utils.getValidatedScope).to.have.been.calledWith({
-            scope: 'minor',
-            maxScope: 'major',
-            prNumber: '12345',
-            prUrl: 'my-pr-url'
+        describe('when one scope checked and other scopes mentioned', function () {
+          beforeEach(function () {
+            pr.description = `
+    ### Check the scope of this pr:
+    *  [ ] #patch# - bugfix, dependency update
+    *  [x] #minor# - new feature, backwards compatible
+    *  [ ] #major# - major feature, probably breaking API
+    *  [ ] #breaking# - any change that breaks the API
+
+    Thought this might be #breaking# but on second thought it is a minor change
+    `
+            scope = utils.getScopeForPr(pr)
+          })
+
+          it('should call .getValidatedScope() with proper arguments', function () {
+            expect(utils.getValidatedScope).to.have.been.calledWith({
+              scope: 'minor',
+              maxScope: 'major',
+              prNumber: '12345',
+              prUrl: 'my-pr-url'
+            })
           })
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Resolves #127 

# CHANGELOG

*   `Added` support for using asterisk in GFM list instead of hyphens if desired, since it is valid Github markdown (Fixes [#127](https://github.com/ciena-blueplanet/pr-bumper/issues/127))
