### PR TITLE
Add new version number to bump commit message

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -345,7 +345,7 @@ class Bumper {
       .then(() => {
         // Currently there are only two reasons we'll have a commit 1) we have a "none" bump with coverage
         // change, or 2) we have a legit bump commit
-        let msg = 'Automated version bump'
+        let msg = `Automated version bump to ${info.version}`
         if (info.scope === 'none') {
           msg = 'Automated code coverage update'
         }

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -1271,7 +1271,8 @@ describe('Bumper', function () {
       info = {
         changelog: 'stuff changed',
         modifiedFiles: [],
-        scope: 'patch'
+        scope: 'patch',
+        version: '1.2.3'
       }
       __.set(bumper.config, 'computed.ci.buildNumber', '12345')
 
@@ -1358,7 +1359,7 @@ describe('Bumper', function () {
       })
 
       it('should commit with version bump message', function () {
-        const msg = `[${pkgJson.name}] Automated version bump`
+        const msg = `[${pkgJson.name}] Automated version bump to 1.2.3`
         const descr = 'From CI build 12345'
         expect(bumper.ci.commit).to.have.been.calledWith(msg, descr)
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
### Added
- New version number in the bump commit message (fixes [#118](https://github.com/ciena-blueplanet/pr-bumper/issues/118))
