### PR TITLE
Add storing bump info to file

### DIFF
--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -8,6 +8,10 @@
     },
     "dependencies": {
       "enabled": true
+    },
+    "logging": {
+      "enabled": true,
+      "file": ".pr-bumper.log"
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
 - .travis/maybe-test.sh
 - .travis/maybe-check-coverage.sh
 - .travis/maybe-bump-version.sh
+- .travis/maybe-cat-log.sh .pr-bumper.log
 after_success:
 - .travis/maybe-publish-coverage.sh
 addons:

--- a/.travis/maybe-cat-log.sh
+++ b/.travis/maybe-cat-log.sh
@@ -19,4 +19,9 @@ then
     LOG_FILE=$1
 fi
 
-cat $LOG_FILE
+if [ -e $LOG_FILE ]
+then
+    cat $LOG_FILE
+else
+    echo "No $LOG_FILE to cat"
+fi

--- a/.travis/maybe-cat-log.sh
+++ b/.travis/maybe-cat-log.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+source $(dirname $0)/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping pr-bumper cat log step for version bump commit"
+  exit 0
+fi
+
+if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-8.1.2}" ]
+then
+  echo "Skipping pr-bumper cat log step for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
+  exit 0
+fi
+
+LOG_FILE=pr-bumper-log.json
+if [ $# -eq 1 ]
+then
+    LOG_FILE=$1
+fi
+
+cat $LOG_FILE

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Here are the defaults that are provided by `pr-bumper` and can be overwritten by
       "maxScope": {
         "enabled": false,
         "value": "major"
+      },
+      "logging": {
+        "enabled": false,
+        "file": "pr-bumper-log.json"
       }
     },
     "vcs": {
@@ -429,6 +433,36 @@ Set this value to `true` to enable the maxScope check.
 
 ##### `features.maxScope.value`
 The value to use for the maximum scope (default is `major`), must be one of [`major`, `minor`, `patch`, `none`]
+
+#### `features.logging`
+Log what `pr-bumper` does during a `bump` to a file, so the information can be used by another tool later on.
+
+The log file that will be created will look something like this:
+
+```json
+{
+  "changelog": "### Added\n- Some cool new feature",
+  "pr": {
+    "number": 123,
+    "url": "https://github.com/ciena-blueplanet/pr-bumper/pull/123"
+  },
+  "scope": "minor",
+  "version": "1.3.0",
+}
+```
+
+- `changelog` - The full text of the changelog that was added during this `bump`
+- `pr.number` - The pull request number that was merged for this `bump`
+- `pr.url` - The URL for the pull request that was merged for this `bump`
+- `scope` - the scope of the `bump` performed
+- `version` - the new version after the `bump`
+
+##### `features.logging.enabled`
+Set this value to `true` to enable the creation of the log file during a `bump`.
+
+##### `features.logging.file`
+The name of the file to create after a `bump`, the contents of the file will be `json` regardless of the name of
+the file given here.
 
 ### `vcs`
 Holds all the information `pr-bumper` needs to interact with your version control system.

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -124,6 +124,9 @@ class Bumper {
       .then((info) => {
         return this._maybePushChanges(info)
       })
+      .then((info) => {
+        return this._maybeLogChanges(info)
+      })
   }
 
   /**
@@ -434,6 +437,27 @@ class Bumper {
       })
       .then(() => {
         addModifiedFile(info, snapshotFile)
+        return info
+      })
+  }
+
+  /**
+   * Maybe log changes to a file
+   * @param {PrInfo} info - the info for the PR being bumped
+   * @returns {Promise} - a promise resolved with the results of the git commands
+   */
+  _maybeLogChanges (info) {
+    if (!this.config.isEnabled('logging')) {
+      logger.log('Skipping logging because of config option.')
+      return Promise.resolve(info)
+    }
+
+    const logInfo = __.cloneDeep(info)
+    delete logInfo.modifiedFiles
+
+    const filename = this.config.features.logging.file
+    return writeFile(filename, JSON.stringify(logInfo, null, 2))
+      .then(() => {
         return info
       })
   }

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -250,7 +250,9 @@ class Bumper {
         return {
           changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
           modifiedFiles: [],
-          scope: scope
+          number: pr.number,
+          scope,
+          url: pr.url
         }
       })
   }
@@ -282,11 +284,11 @@ class Bumper {
         if (getChangelog) {
           return utils.maybePostCommentOnError(this.config, this.vcs, () => {
             changelog = utils.getChangelogForPr(pr)
-            return {changelog, scope}
+            return {changelog, number: pr.number, scope, url: pr.url}
           })
         }
 
-        return Promise.resolve({changelog, scope})
+        return Promise.resolve({changelog, number: pr.number, scope, url: pr.url})
       })
   }
 

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -217,9 +217,11 @@
  * Generic Pull Request info (used for updating package.json and CHANGELOG.md files)
  *
  * @typedef PrInfo
- * @property {String} scope - the scope of the PR
- * @property {String} version - the new version after bumping based on scope
  * @property {String} changelog - the changelog text
+ * @property {Number} number - the PR #
+ * @property {String} scope - the scope of the PR
+ * @property {String} url - the URL for the web interface of the PR
+ * @property {String} version - the new version after bumping based on scope
  */
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,6 +198,10 @@ const utils = {
         maxScope: {
           enabled: false,
           value: 'major'
+        },
+        logging: {
+          enabled: false,
+          file: 'pr-bumper-log.json'
         }
       },
       vcs: {

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -763,7 +763,7 @@ describe('Bumper', function () {
   describe('._getMergedPrInfo()', function () {
     ;['major', 'minor', 'patch'].forEach(function (scope) {
       describe(`when scope is ${scope}`, function () {
-        let result
+        let result, pr
 
         beforeEach(function () {
           bumper.config = {
@@ -777,7 +777,8 @@ describe('Bumper', function () {
           }
           bumper.vcs = {bar: 'baz'}
 
-          sandbox.stub(bumper, '_getLastPr').returns(Promise.resolve('the-pr'))
+          pr = {number: 123, url: 'pr-url'}
+          sandbox.stub(bumper, '_getLastPr').returns(Promise.resolve(pr))
           sandbox.stub(utils, 'getScopeForPr').returns(scope)
           sandbox.stub(utils, 'getChangelogForPr').returns('my-changelog')
         })
@@ -800,15 +801,21 @@ describe('Bumper', function () {
             })
 
             it('should gets the scope for the given pr', function () {
-              expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'minor')
+              expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'minor')
             })
 
             it('should get the changelog for the given pr', function () {
-              expect(utils.getChangelogForPr).to.have.been.calledWith('the-pr')
+              expect(utils.getChangelogForPr).to.have.been.calledWith(pr)
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.deep.equal({changelog: 'my-changelog', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({
+                changelog: 'my-changelog',
+                modifiedFiles: [],
+                number: 123,
+                scope,
+                url: 'pr-url'
+              })
             })
           })
 
@@ -825,7 +832,7 @@ describe('Bumper', function () {
             })
 
             it('should gets the scope for the given pr', function () {
-              expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'minor')
+              expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'minor')
             })
 
             it('should not get the changelog for the given pr', function () {
@@ -833,7 +840,13 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({
+                changelog: '',
+                modifiedFiles: [],
+                number: 123,
+                scope,
+                url: 'pr-url'
+              })
             })
           })
         })
@@ -856,15 +869,21 @@ describe('Bumper', function () {
             })
 
             it('should gets the scope for the given pr', function () {
-              expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+              expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
             })
 
             it('should get the changelog for the given pr', function () {
-              expect(utils.getChangelogForPr).to.have.been.calledWith('the-pr')
+              expect(utils.getChangelogForPr).to.have.been.calledWith(pr)
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.deep.equal({changelog: 'my-changelog', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({
+                changelog: 'my-changelog',
+                modifiedFiles: [],
+                number: 123,
+                scope,
+                url: 'pr-url'
+              })
             })
           })
 
@@ -881,7 +900,7 @@ describe('Bumper', function () {
             })
 
             it('should gets the scope for the given pr', function () {
-              expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+              expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
             })
 
             it('should not get the changelog for the given pr', function () {
@@ -889,7 +908,13 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({
+                changelog: '',
+                modifiedFiles: [],
+                number: 123,
+                scope,
+                url: 'pr-url'
+              })
             })
           })
         })
@@ -897,13 +922,14 @@ describe('Bumper', function () {
     })
 
     describe('when scope is none', function () {
-      let result
+      let result, pr
 
       beforeEach(function () {
         bumper.config = {foo: 'bar', isEnabled: sandbox.stub()}
         bumper.vcs = {bar: 'baz'}
 
-        sandbox.stub(bumper, '_getLastPr').returns(Promise.resolve('the-pr'))
+        pr = {number: 123, url: 'pr-url'}
+        sandbox.stub(bumper, '_getLastPr').returns(Promise.resolve(pr))
         sandbox.stub(utils, 'getScopeForPr').returns('none')
         sandbox.stub(utils, 'getChangelogForPr').returns('my-changelog')
       })
@@ -921,7 +947,7 @@ describe('Bumper', function () {
         })
 
         it('should gets the scope for the given pr', function () {
-          expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+          expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
         })
 
         it('should not get the changelog for the given pr', function () {
@@ -929,7 +955,13 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope: 'none'})
+          expect(result).to.deep.equal({
+            changelog: '',
+            modifiedFiles: [],
+            number: 123,
+            scope: 'none',
+            url: 'pr-url'
+          })
         })
       })
 
@@ -946,7 +978,7 @@ describe('Bumper', function () {
         })
 
         it('should gets the scope for the given pr', function () {
-          expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+          expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
         })
 
         it('should not get the changelog for the given pr', function () {
@@ -954,14 +986,20 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope: 'none'})
+          expect(result).to.deep.equal({
+            changelog: '',
+            modifiedFiles: [],
+            number: 123,
+            scope: 'none',
+            url: 'pr-url'
+          })
         })
       })
     })
   })
 
   describe('._getOpenPrInfo()', function () {
-    let result
+    let result, pr
     beforeEach(function () {
       bumper.config = {
         foo: 'bar',
@@ -974,18 +1012,18 @@ describe('Bumper', function () {
       }
       bumper.vcs = {getPr () {}}
 
-      sandbox.stub(bumper.vcs, 'getPr').returns(Promise.resolve('the-pr'))
+      pr = {number: 123, url: 'pr-url'}
+      sandbox.stub(bumper.vcs, 'getPr').returns(Promise.resolve(pr))
       sandbox.stub(utils, 'getScopeForPr').returns('patch')
       sandbox.stub(utils, 'getChangelogForPr').returns('the-changelog')
 
       sandbox.stub(utils, 'maybePostCommentOnError')
-      utils.maybePostCommentOnError.onCall(0).resolves({
-        pr: 'the-pr',
-        scope: 'the-scope'
-      })
+      utils.maybePostCommentOnError.onCall(0).resolves({pr, scope: 'the-scope'})
       utils.maybePostCommentOnError.onCall(1).resolves({
         changelog: 'the-changelog',
-        scope: 'the-scope'
+        number: 123,
+        scope: 'the-scope',
+        url: 'pr-url'
       })
     })
 
@@ -1016,7 +1054,9 @@ describe('Bumper', function () {
       it('should resolve with the info', function () {
         expect(result).to.deep.equal({
           changelog: '',
-          scope: 'the-scope'
+          number: 123,
+          scope: 'the-scope',
+          url: 'pr-url'
         })
       })
 
@@ -1042,13 +1082,11 @@ describe('Bumper', function () {
           })
 
           it('should get the scope', function () {
-            expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+            expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.deep.equal({
-              pr: 'the-pr',
-              scope: 'patch'
+            expect(ret).to.deep.equal({pr, scope: 'patch'
             })
           })
         })
@@ -1084,7 +1122,9 @@ describe('Bumper', function () {
       it('should resolve with the info', function () {
         expect(result).to.deep.equal({
           changelog: '',
-          scope: 'the-scope'
+          number: 123,
+          scope: 'the-scope',
+          url: 'pr-url'
         })
       })
 
@@ -1110,25 +1150,23 @@ describe('Bumper', function () {
           })
 
           it('should get the scope', function () {
-            expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'minor')
+            expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'minor')
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.deep.equal({
-              pr: 'the-pr',
-              scope: 'patch'
-            })
+            expect(ret).to.deep.equal({pr, scope: 'patch'})
           })
         })
       })
     })
 
     describe('when changelog is enabled', function () {
-      beforeEach(function () {
+      beforeEach(function (done) {
         bumper.config.isEnabled.returns(false)
         bumper.config.isEnabled.withArgs('changelog').returns(true)
         return bumper._getOpenPrInfo().then((res) => {
           result = res
+          done()
         })
       })
 
@@ -1151,7 +1189,9 @@ describe('Bumper', function () {
       it('should resolve with the info', function () {
         expect(result).to.deep.equal({
           changelog: 'the-changelog',
-          scope: 'the-scope'
+          number: 123,
+          scope: 'the-scope',
+          url: 'pr-url'
         })
       })
 
@@ -1177,14 +1217,11 @@ describe('Bumper', function () {
           })
 
           it('should get the scope', function () {
-            expect(utils.getScopeForPr).to.have.been.calledWith('the-pr', 'major')
+            expect(utils.getScopeForPr).to.have.been.calledWith(pr, 'major')
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.deep.equal({
-              pr: 'the-pr',
-              scope: 'patch'
-            })
+            expect(ret).to.deep.equal({pr, scope: 'patch'})
           })
         })
       })
@@ -1210,13 +1247,15 @@ describe('Bumper', function () {
           })
 
           it('should get the changelog', function () {
-            expect(utils.getChangelogForPr).to.have.been.calledWith('the-pr')
+            expect(utils.getChangelogForPr).to.have.been.calledWith(pr)
           })
 
-          it('should return the changelog and scope', function () {
+          it('should return the changelog and scope, plus pr info', function () {
             expect(ret).to.deep.equal({
               changelog: 'the-changelog',
-              scope: 'the-scope'
+              number: 123,
+              scope: 'the-scope',
+              url: 'pr-url'
             })
           })
         })

--- a/tests/bumper-spec.js
+++ b/tests/bumper-spec.js
@@ -808,7 +808,7 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.eql({changelog: 'my-changelog', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({changelog: 'my-changelog', modifiedFiles: [], scope})
             })
           })
 
@@ -833,7 +833,7 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.eql({changelog: '', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope})
             })
           })
         })
@@ -864,7 +864,7 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.eql({changelog: 'my-changelog', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({changelog: 'my-changelog', modifiedFiles: [], scope})
             })
           })
 
@@ -889,7 +889,7 @@ describe('Bumper', function () {
             })
 
             it('should resolve with the info', function () {
-              expect(result).to.eql({changelog: '', modifiedFiles: [], scope})
+              expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope})
             })
           })
         })
@@ -929,7 +929,7 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.eql({changelog: '', modifiedFiles: [], scope: 'none'})
+          expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope: 'none'})
         })
       })
 
@@ -954,7 +954,7 @@ describe('Bumper', function () {
         })
 
         it('should resolve with the info', function () {
-          expect(result).to.eql({changelog: '', modifiedFiles: [], scope: 'none'})
+          expect(result).to.deep.equal({changelog: '', modifiedFiles: [], scope: 'none'})
         })
       })
     })
@@ -1014,7 +1014,7 @@ describe('Bumper', function () {
       })
 
       it('should resolve with the info', function () {
-        expect(result).to.eql({
+        expect(result).to.deep.equal({
           changelog: '',
           scope: 'the-scope'
         })
@@ -1046,7 +1046,7 @@ describe('Bumper', function () {
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.eql({
+            expect(ret).to.deep.equal({
               pr: 'the-pr',
               scope: 'patch'
             })
@@ -1082,7 +1082,7 @@ describe('Bumper', function () {
       })
 
       it('should resolve with the info', function () {
-        expect(result).to.eql({
+        expect(result).to.deep.equal({
           changelog: '',
           scope: 'the-scope'
         })
@@ -1114,7 +1114,7 @@ describe('Bumper', function () {
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.eql({
+            expect(ret).to.deep.equal({
               pr: 'the-pr',
               scope: 'patch'
             })
@@ -1149,7 +1149,7 @@ describe('Bumper', function () {
       })
 
       it('should resolve with the info', function () {
-        expect(result).to.eql({
+        expect(result).to.deep.equal({
           changelog: 'the-changelog',
           scope: 'the-scope'
         })
@@ -1181,7 +1181,7 @@ describe('Bumper', function () {
           })
 
           it('should return the pr and scope', function () {
-            expect(ret).to.eql({
+            expect(ret).to.deep.equal({
               pr: 'the-pr',
               scope: 'patch'
             })
@@ -1214,7 +1214,7 @@ describe('Bumper', function () {
           })
 
           it('should return the changelog and scope', function () {
-            expect(ret).to.eql({
+            expect(ret).to.deep.equal({
               changelog: 'the-changelog',
               scope: 'the-scope'
             })

--- a/tests/ci/bamboo-spec.js
+++ b/tests/ci/bamboo-spec.js
@@ -32,11 +32,11 @@ describe('CI / Bamboo', function () {
   })
 
   it('should save the config', function () {
-    expect(bamboo.config).to.eql({id: 'config'})
+    expect(bamboo.config).to.deep.equal({id: 'config'})
   })
 
   it('should save the vcs', function () {
-    expect(bamboo.vcs).to.eql({id: 'vcs'})
+    expect(bamboo.vcs).to.deep.equal({id: 'vcs'})
   })
 
   it('should extend CiBase', function () {

--- a/tests/ci/base-spec.js
+++ b/tests/ci/base-spec.js
@@ -45,7 +45,7 @@ describe('CI / Base', function () {
   })
 
   it('should save the vcs', function () {
-    expect(base.vcs).to.eql({id: 'vcs'})
+    expect(base.vcs).to.deep.equal({id: 'vcs'})
   })
 
   describe('.add()', function () {

--- a/tests/ci/teamcity-spec.js
+++ b/tests/ci/teamcity-spec.js
@@ -32,11 +32,11 @@ describe('CI / TeamCity', function () {
   })
 
   it('should save the config', function () {
-    expect(teamcity.config).to.eql({id: 'config'})
+    expect(teamcity.config).to.deep.equal({id: 'config'})
   })
 
   it('should save the vcs', function () {
-    expect(teamcity.vcs).to.eql({id: 'vcs'})
+    expect(teamcity.vcs).to.deep.equal({id: 'vcs'})
   })
 
   it('should extend CiBase', function () {

--- a/tests/ci/travis-spec.js
+++ b/tests/ci/travis-spec.js
@@ -51,7 +51,7 @@ describe('CI / Travis', function () {
   })
 
   it('should save the vcs', function () {
-    expect(travis.vcs).to.eql({id: 'vcs'})
+    expect(travis.vcs).to.deep.equal({id: 'vcs'})
   })
 
   it('should extend CiBase', function () {

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -287,11 +287,11 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(ci.config).to.eql(config)
+        expect(ci.config).to.deep.equal(config)
       })
 
       it('should pass along vcs', function () {
-        expect(ci.vcs).to.eql(vcs)
+        expect(ci.vcs).to.deep.equal(vcs)
       })
 
       it('should create a TeamCity instance', function () {
@@ -306,11 +306,11 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(ci.config).to.eql(config)
+        expect(ci.config).to.deep.equal(config)
       })
 
       it('should pass along vcs', function () {
-        expect(ci.vcs).to.eql(vcs)
+        expect(ci.vcs).to.deep.equal(vcs)
       })
 
       it('should create a Travis instance', function () {
@@ -325,11 +325,11 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(ci.config).to.eql(config)
+        expect(ci.config).to.deep.equal(config)
       })
 
       it('should pass along vcs', function () {
-        expect(ci.vcs).to.eql(vcs)
+        expect(ci.vcs).to.deep.equal(vcs)
       })
 
       it('should create a Travis instance', function () {
@@ -375,7 +375,7 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(vcs.config).to.eql(config)
+        expect(vcs.config).to.deep.equal(config)
       })
 
       it('should create a BitbucketServer instance', function () {
@@ -394,7 +394,7 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(vcs.config).to.eql(config)
+        expect(vcs.config).to.deep.equal(config)
       })
 
       it('should create a Bitbucket instance', function () {
@@ -409,7 +409,7 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(vcs.config).to.eql(config)
+        expect(vcs.config).to.deep.equal(config)
       })
 
       it('should create a GitHub instance', function () {
@@ -424,7 +424,7 @@ describe('Cli', function () {
       })
 
       it('should pass along config', function () {
-        expect(vcs.config).to.eql(config)
+        expect(vcs.config).to.deep.equal(config)
       })
 
       it('should create a GitHubEnterprise instance', function () {

--- a/tests/compliance/dependencies-spec.js
+++ b/tests/compliance/dependencies-spec.js
@@ -233,7 +233,7 @@ describe('dependencies', function () {
 
     it('should return file written message', function () {
       return dependencies.getNpmLicenseData('/some/path', '/some/output/path', config).then((value) => {
-        expect(value).to.eql('successfully wrote /some/output/path')
+        expect(value).to.deep.equal('successfully wrote /some/output/path')
       })
     })
 
@@ -262,7 +262,7 @@ describe('dependencies', function () {
       const expectedUrl2 = addlRepos[0].url.split('${REPO_NAME}').join(repos[0].split('"').join(''))
       const expected = `${expectedUrl1}\n${expectedUrl2}\n`
       return dependencies.getPackageData('/some/path', config).then((paths) => {
-        expect(paths).to.eql(expected)
+        expect(paths).to.deep.equal(expected)
       })
     })
   })

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -110,6 +110,18 @@ function verifyFeatureDefaults (ctx, propsToSkip) {
         expect(config.features.maxScope.value).to.equal('major')
       })
     }
+
+    if (propsToSkip.indexOf('features.logging.enabled') === -1) {
+      it('should default logging feature to disabled', function () {
+        expect(config.features.logging.enabled).to.equal(false)
+      })
+    }
+
+    if (propsToSkip.indexOf('features.logging.file') === -1) {
+      it('should default logging file to "pr-bumper-log.json"', function () {
+        expect(config.features.logging.file).to.equal('pr-bumper-log.json')
+      })
+    }
   })
   /* eslint-enable complexity */
 }
@@ -135,7 +147,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
 
     if (propsToSkip.indexOf('ci.gitUser') === -1) {
       it('should use the proper git user', function () {
-        expect(config.ci.gitUser).to.eql({
+        expect(config.ci.gitUser).to.deep.equal({
           email: 'travis.ci.ciena@gmail.com',
           name: 'Travis CI'
         })
@@ -180,7 +192,7 @@ function verifyGitHubTravisDefaults (ctx, propsToSkip) {
 
     if (propsToSkip.indexOf('computed.vcs.auth') === -1) {
       it('should have the proper vcs auth', function () {
-        expect(config.computed.vcs.auth).to.eql({
+        expect(config.computed.vcs.auth).to.deep.equal({
           password: undefined,
           readToken: '12345',
           username: undefined,
@@ -204,7 +216,7 @@ function verifyBitbucketTeamcityOverrides (ctx) {
     })
 
     it('should have the proper git user', function () {
-      expect(config.ci.gitUser).to.eql({
+      expect(config.ci.gitUser).to.deep.equal({
         email: 'teamcity@domain.com',
         name: 'teamcity'
       })
@@ -235,7 +247,7 @@ function verifyBitbucketTeamcityOverrides (ctx) {
     })
 
     it('should have the proper vcs auth', function () {
-      expect(config.computed.vcs.auth).to.eql({
+      expect(config.computed.vcs.auth).to.deep.equal({
         password: 'teamcity12345',
         readToken: undefined,
         username: 'teamcity',
@@ -420,6 +432,10 @@ describe('utils', function () {
               changelog: {
                 enabled: true,
                 file: 'CHANGES.md'
+              },
+              logging: {
+                enabled: true,
+                file: '.pr-bumper.log'
               }
             }
           })
@@ -429,19 +445,31 @@ describe('utils', function () {
         })
 
         verifyGitHubTravisDefaults(ctx, ['ci.gitUser'])
-        verifyFeatureDefaults(ctx, ['features.changelog.enabled', 'features.changelog.file'])
+        verifyFeatureDefaults(ctx, [
+          'features.changelog.enabled',
+          'features.changelog.file',
+          'features.logging.enabled',
+          'features.logging.file'
+        ])
 
         it('should use the overwritten git user', function () {
-          expect(config.ci.gitUser).to.eql({
+          expect(config.ci.gitUser).to.deep.equal({
             email: 'some.other.user@domain.com',
             name: 'Some Other User'
           })
         })
 
         it('should use the overwritten changelog settings', function () {
-          expect(config.features.changelog).to.eql({
+          expect(config.features.changelog).to.deep.equal({
             enabled: true,
             file: 'CHANGES.md'
+          })
+        })
+
+        it('should use the overwritten logging settings', function () {
+          expect(config.features.logging).to.deep.equal({
+            enabled: true,
+            file: '.pr-bumper.log'
           })
         })
       })
@@ -518,7 +546,7 @@ describe('utils', function () {
         verifyFeatureDefaults(ctx, ['features.comments.enabled'])
 
         it('should have the proper gitUser', function () {
-          expect(config.ci.gitUser).to.eql({
+          expect(config.ci.gitUser).to.deep.equal({
             email: 'bot@domain.com',
             name: 'Bot User'
           })
@@ -580,7 +608,7 @@ describe('utils', function () {
         verifyFeatureDefaults(ctx, ['features.compliance.enabled'])
 
         it('should have the proper gitUser', function () {
-          expect(config.ci.gitUser).to.eql({
+          expect(config.ci.gitUser).to.deep.equal({
             email: 'bot@domain.com',
             name: 'Bot User'
           })
@@ -607,7 +635,7 @@ describe('utils', function () {
         })
 
         it('should use the overwritten compliance config', function () {
-          expect(config.features.compliance).to.eql(_config.features.compliance)
+          expect(config.features.compliance).to.deep.equal(_config.features.compliance)
         })
       })
 
@@ -635,7 +663,7 @@ describe('utils', function () {
         verifyFeatureDefaults(ctx, ['features.dependencies.enabled', 'features.dependencies.snapshotFile'])
 
         it('should have the proper gitUser', function () {
-          expect(config.ci.gitUser).to.eql({
+          expect(config.ci.gitUser).to.deep.equal({
             email: 'bot@domain.com',
             name: 'Bot User'
           })
@@ -662,7 +690,7 @@ describe('utils', function () {
         })
 
         it('should have the proper dependencies feature config', function () {
-          expect(config.features.dependencies).to.eql(_config.features.dependencies)
+          expect(config.features.dependencies).to.deep.equal(_config.features.dependencies)
         })
       })
 
@@ -690,7 +718,7 @@ describe('utils', function () {
         verifyFeatureDefaults(ctx, ['features.maxScope.enabled', 'features.maxScope.value'])
 
         it('should have the proper gitUser', function () {
-          expect(config.ci.gitUser).to.eql({
+          expect(config.ci.gitUser).to.deep.equal({
             email: 'bot@domain.com',
             name: 'Bot User'
           })
@@ -717,7 +745,7 @@ describe('utils', function () {
         })
 
         it('should have the proper maxScope config', function () {
-          expect(config.features.maxScope).to.eql(_config.features.maxScope)
+          expect(config.features.maxScope).to.deep.equal(_config.features.maxScope)
         })
       })
     })
@@ -1423,7 +1451,7 @@ describe('utils', function () {
       })
 
       it('should grab the changelog text', function () {
-        expect(changelog).to.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+        expect(changelog).to.deep.equal('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
       })
     })
 
@@ -1434,7 +1462,7 @@ describe('utils', function () {
       })
 
       it('should grab the changelog text', function () {
-        expect(changelog).to.eql('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
+        expect(changelog).to.deep.equal('## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang')
       })
     })
   })
@@ -1848,7 +1876,7 @@ describe('utils', function () {
         })
 
         it('should reject with the error thrown', function () {
-          expect(error).to.eql(new Error('Uh oh!'))
+          expect(error).to.deep.equal(new Error('Uh oh!'))
         })
 
         it('should not resolve', function () {
@@ -1880,7 +1908,7 @@ describe('utils', function () {
         })
 
         it('should reject with the error thrown', function () {
-          expect(error).to.eql(new Error('Uh oh!'))
+          expect(error).to.deep.equal(new Error('Uh oh!'))
         })
 
         it('should not resolve', function () {

--- a/tests/vcs/bitbucket-server-spec.js
+++ b/tests/vcs/bitbucket-server-spec.js
@@ -58,7 +58,7 @@ describe('VCS / BitbucketServer /', function () {
   })
 
   it('should save the config', function () {
-    expect(bitbucket.config).to.be.eql(config)
+    expect(bitbucket.config).to.be.deep.equal(config)
   })
 
   it('should construct a base URL', function () {
@@ -132,7 +132,7 @@ describe('VCS / BitbucketServer /', function () {
       })
 
       it('should resolve with the correct PR', function () {
-        expect(resolution).to.be.eql({
+        expect(resolution).to.be.deep.equal({
           description: 'This is a #fix#',
           headSha: 'sha-1',
           number: 5,
@@ -162,7 +162,7 @@ describe('VCS / BitbucketServer /', function () {
       })
 
       it('should reject with the proper error', function () {
-        expect(rejection).to.be.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.be.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 
@@ -248,7 +248,7 @@ describe('VCS / BitbucketServer /', function () {
       })
 
       it('should reject with proper error', function () {
-        expect(rejection).to.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 

--- a/tests/vcs/bitbucket-spec.js
+++ b/tests/vcs/bitbucket-spec.js
@@ -58,7 +58,7 @@ describe('VCS / Bitbucket /', function () {
   })
 
   it('should save the config', function () {
-    expect(bitbucket.config).to.be.eql(config)
+    expect(bitbucket.config).to.be.deep.equal(config)
   })
 
   it('should construct a 1.0 base URL', function () {
@@ -139,7 +139,7 @@ describe('VCS / Bitbucket /', function () {
       })
 
       it('should resolve with the correct PR', function () {
-        expect(resolution).to.be.eql({
+        expect(resolution).to.be.deep.equal({
           description: 'This is a #fix#',
           headSha: 'sha-1',
           number: 5,
@@ -169,7 +169,7 @@ describe('VCS / Bitbucket /', function () {
       })
 
       it('should reject with the proper error', function () {
-        expect(rejection).to.be.eql(new Error(`https://api.bitbucket.org/2.0/repositories/owner/repo/pullrequests/5 400: ${JSON.stringify(err)}`))
+        expect(rejection).to.be.deep.equal(new Error(`https://api.bitbucket.org/2.0/repositories/owner/repo/pullrequests/5 400: ${JSON.stringify(err)}`))
       })
     })
 
@@ -253,7 +253,7 @@ describe('VCS / Bitbucket /', function () {
       })
 
       it('should reject with proper error', function () {
-        expect(rejection).to.eql(new Error('400: API 1.0 Error'))
+        expect(rejection).to.deep.equal(new Error('400: API 1.0 Error'))
       })
     })
 

--- a/tests/vcs/github-enterprise-spec.js
+++ b/tests/vcs/github-enterprise-spec.js
@@ -66,7 +66,7 @@ describe('VCS / GitHub Enterprise /', function () {
   })
 
   it('should save the config', function () {
-    expect(github.config).to.be.eql(config)
+    expect(github.config).to.be.deep.equal(config)
   })
 
   describe('.addRemoteForPush()', function () {
@@ -80,7 +80,7 @@ describe('VCS / GitHub Enterprise /', function () {
 
     it('should makes the proper git remote command', function () {
       const url = 'https://my-gh-token@my-ghe.com/me/my-repo'
-      expect(execStub.firstCall.args).to.be.eql([`git remote add ci-origin ${url}`])
+      expect(execStub.firstCall.args).to.be.deep.equal([`git remote add ci-origin ${url}`])
     })
 
     it('should resolve with the proper remote name', function () {
@@ -144,7 +144,7 @@ describe('VCS / GitHub Enterprise /', function () {
       })
 
       it('should resolve with the correct PR', function () {
-        expect(resolution).to.be.eql({
+        expect(resolution).to.be.deep.equal({
           description: 'This is a #fix#',
           headSha: 'sha-1',
           number: 5,
@@ -174,7 +174,7 @@ describe('VCS / GitHub Enterprise /', function () {
       })
 
       it('should reject with the proper error', function () {
-        expect(rejection).to.be.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.be.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 
@@ -260,7 +260,7 @@ describe('VCS / GitHub Enterprise /', function () {
       })
 
       it('should reject with proper error', function () {
-        expect(rejection).to.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 

--- a/tests/vcs/github-spec.js
+++ b/tests/vcs/github-spec.js
@@ -65,7 +65,7 @@ describe('VCS / GitHub /', function () {
   })
 
   it('should save the config', function () {
-    expect(github.config).to.be.eql(config)
+    expect(github.config).to.be.deep.equal(config)
   })
 
   describe('.addRemoteForPush()', function () {
@@ -79,7 +79,7 @@ describe('VCS / GitHub /', function () {
 
     it('should makes the proper git remote command', function () {
       const url = 'https://my-gh-token@github.com/me/my-repo'
-      expect(execStub.firstCall.args).to.be.eql([`git remote add ci-origin ${url}`])
+      expect(execStub.firstCall.args).to.be.deep.equal([`git remote add ci-origin ${url}`])
     })
 
     it('should resolve with the proper remote name', function () {
@@ -143,7 +143,7 @@ describe('VCS / GitHub /', function () {
       })
 
       it('should resolve with the correct PR', function () {
-        expect(resolution).to.be.eql({
+        expect(resolution).to.be.deep.equal({
           description: 'This is a #fix#',
           headSha: 'sha-1',
           number: 5,
@@ -173,7 +173,7 @@ describe('VCS / GitHub /', function () {
       })
 
       it('should reject with the proper error', function () {
-        expect(rejection).to.be.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.be.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 
@@ -259,7 +259,7 @@ describe('VCS / GitHub /', function () {
       })
 
       it('should reject with proper error', function () {
-        expect(rejection).to.eql(new Error(`400: ${JSON.stringify(err)}`))
+        expect(rejection).to.deep.equal(new Error(`400: ${JSON.stringify(err)}`))
       })
     })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
### Added
- New `logging` feature, which outputs information related to the bump action and the PR that caused it during a `bump` command. (Fixes [#125](https://github.com/ciena-blueplanet/pr-bumper/issues/125))
- New `maybe-cat-log.sh` script to `.travis` to help people debug their use of the new `logging` feature. 

### Changed
- Our own `.pr-bumper.json` to enable the new `logging` feature
- Our own `.travis.yml` file to use the new `maybe-cat-log.sh` to log our generated log file contents during CI
