### PR TITLE
Remove unwanted check in maybe-cat-log.sh

### DIFF
--- a/.travis/maybe-cat-log.sh
+++ b/.travis/maybe-cat-log.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-source $(dirname $0)/is-bump-commit.sh
-
-if isBumpCommit
-then
-  echo "Skipping pr-bumper cat log step for version bump commit"
-  exit 0
-fi
 
 if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-8.1.2}" ]
 then


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
### Changed
- `.travis/maybe-cat-log.sh` to not skip the bump commit, as that's when the log file would actually be created. 
