### PR TITLE
Allow non-exact Node version in travis config

### DIFF
--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -7,7 +7,7 @@ then
   exit 0
 fi
 
-if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-8.1.2}" ]
+if [[ ! "${PUBLISH_NODE_VERSION:-8.1.2}" =~ ^$TRAVIS_NODE_VERSION ]]
 then
   echo "Skipping pr-bumper bump step for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
   exit 0

--- a/.travis/maybe-cat-log.sh
+++ b/.travis/maybe-cat-log.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-8.1.2}" ]
+if [[ ! "${PUBLISH_NODE_VERSION:-8.1.2}" =~ ^$TRAVIS_NODE_VERSION ]]
 then
   echo "Skipping pr-bumper cat log step for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "${PUBLISH_NODE_VERSION:-8.1.2}" ]
+if [[ ! "${PUBLISH_NODE_VERSION:-8.1.2}" =~ ^$TRAVIS_NODE_VERSION ]]
 then
   echo "Skipping coverage publish for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
   exit 0


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

I tested the change by slightly changing the script to be:

```bash
#!/bin/bash
# source $(dirname $0)/is-bump-commit.sh
#
# if isBumpCommit
# then
#   echo "Skipping pr-bumper bump step for version bump commit"
#   exit 0
# fi

if [[ ! "${PUBLISH_NODE_VERSION:-8.1.2}" =~ ^$TRAVIS_NODE_VERSION ]]
then
  echo "Skipping pr-bumper bump step for TRAVIS_NODE_VERSION [${TRAVIS_NODE_VERSION}]"
  exit 0
fi

PACKAGE_NAME=$(node -p -e "require('./package.json').name")

if [ "$PACKAGE_NAME" == "pr-bumper" ]
then
  echo "bump it"
  # VERBOSE=1 ./bin/cli.js bump
else
  echo "bump it"
  # pr-bumper bump
fi
```

and running the following:

```bash
$ TRAVIS_NODE_VERSION=6 .travis/maybe-bump-version.sh 
Skipping pr-bumper bump step for TRAVIS_NODE_VERSION [6]
$ TRAVIS_NODE_VERSION=8 .travis/maybe-bump-version.sh 
bump it
$ TRAVIS_NODE_VERSION=8.1.2 .travis/maybe-bump-version.sh 
bump it
$ TRAVIS_NODE_VERSION=8.1.21 .travis/maybe-bump-version.sh 
Skipping pr-bumper bump step for TRAVIS_NODE_VERSION [8.1.21]
```

# CHANGELOG

* Updated shell scripts to handle Travis config files that specify a non-exact Node version, for example using `8` instead of `8.1.2`. (resolves #135)
