### PR TITLE
Check if file exists before trying to read it

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -440,9 +440,14 @@ const utils = {
   /**
    * Read in a JSON file and return the parsed json
    * @param {String} filename - the name of the file to read
-   * @returns {Object} the json object
+   * @returns {Object|undefined} the json object
    */
   readJsonFile (filename) {
+    if (!fs.existsSync(filename)) {
+      logger.log(`File ${filename} was not found.`)
+      return
+    }
+
     const fullPath = path.join(process.cwd(), filename)
     return JSON.parse(fs.readFileSync(fullPath, {encoding: 'utf8'}))
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "sinon-chai": "^2.11.0"
   },
   "pr-bumper": {
-    "coverage": 93.71
+    "coverage": 93.18
   }
 }

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1503,6 +1503,17 @@ describe('utils', function () {
       })
     })
 
+    describe('when readJsonFile() does not find the file', function () {
+      beforeEach(function () {
+        utils.readJsonFile.withArgs('path-to-coverage/coverage-file.json').returns(undefined)
+        pct = utils.getCurrentCoverage(config)
+      })
+
+      it('should return -1', function () {
+        expect(pct).to.equal(-1)
+      })
+    })
+
     describe('when coverage is present', function () {
       beforeEach(function () {
         utils.readJsonFile.withArgs('path-to-coverage/coverage-file.json').returns(coverageSummary)


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No, this issue was found while upgrading the TeamCity build containers. If a file does not exist, this repo's readJsonFile() method was previously throwing an uncaught error.
## Summary
Check if file exists before trying to read it

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Checklist
* [X] I have added tests that prove my fix is effective or that my feature works
* [X] I have evaluated if the _README.md_ documentation needs to be updated
* [X] I have evaluated if DocBlock headers needed to be added or updated
* [X] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [X] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome

# CHANGELOG
* **Updated** `readJsonFile()` method to check if a file exists before trying to read it.
* **Updated** tests for `readJsonFile()` to verify modified behavior