### PR TITLE
Add handling of mono-repo

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,15 +11,11 @@ const cli = new Cli()
 program
   .version(pkgJson.version)
   .option('-s, --skip-comments', 'disable PR comments even if enabled via .pr-bumper.json')
+  .option('-mr, --mono-repo', 'provide a different behavior for mono-repo')
   .arguments('<cmd>')
   .action((cmd, program) => {
     cli
-      .run(cmd, program.skipComments)
-      .then(result => {
-        if (result) {
-          console.log(result)
-        }
-      })
+      .run(cmd, program.skipComments, program.morepo)
       .catch((error) => {
         const msg = (error.message) ? error.message : error
         console.log(`${pkgJson.name}: ERROR: ${msg}`)
@@ -34,7 +30,9 @@ program
     console.log('')
     console.log(
       '    --skip-comments - disable PR comments even if enabled via .pr-bumper.json\n' +
-      '                      Useful particularly when running check-coverage manually'
+      '                      Useful particularly when running check-coverage manually' +
+      '    --mono-repo - provide a different behavior for mono-repo\n' +
+      '                  Useful particularly when running check and bump'
     )
     console.log('')
     console.log('  Commands:')

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -129,21 +129,44 @@ class Bumper {
       })
   }
 
-  prependChangelog () {
+  /**
+   * Bump the version based on the last merged PR's version-bump comment
+   * @param {Object} options the cli options
+   * @returns {Promise} a promise resolved with the results of the push
+   */
+  bumpMonoRepo () {
     if (__.get(this.config, 'computed.ci.isPr')) {
       logger.log('Not a merge build, skipping bump')
       return Promise.resolve()
     }
 
-    return this._getMergedPrInfo()
-      .then((info) => {
-        return this._maybePrependChangelog(info)
+    return this.ci.getLastCommitMsg()
+      .then((commitMessage) => {
+        if (commitMessage.startsWith(`[${pkgJson.name}]`)) {
+          throw new Cancel(`Skipping bump on ${pkgJson.name} commit.`)
+        }
+        return Promise.resolve()
+      })
+      .then(() => {
+        return this._getMergedPrInfo()
       })
       .then((info) => {
-        return this._maybeCommitChanges(info, true)
+        return this._publishMonoRepo(info)
+      })
+      .then((info) => {
+        return this._getMonoRepoPackagesInfo()
+      })
+      .then(({info, packagesInfo}) => {
+        return this._maybePrependChangelogMonoRepo(info, packagesInfo)
+      })
+      .then((info) => {
+        return this._maybeCommitChanges(info)
       })
       .then((info) => {
         return this._maybePushChanges(info)
+      })
+      .then((info) => {
+        return this._maybeLogChanges(info)
       })
   }
 
@@ -500,10 +523,9 @@ class Bumper {
       return Promise.resolve(info)
     }
 
-    const now = new Date()
-    const dateString = now.toISOString().split('T').slice(0, 1).join('')
+    const dateString = this._getChangelogTextDate()
 
-    const data = `# ${info.version} (${dateString})\n${info.changelog}\n\n`
+    const data = this._getChangelogText(info.version, dateString, info.changelog)
     const filename = this.config.features.changelog.file
     return prepend(filename, data)
       .then(() => {
@@ -563,6 +585,62 @@ class Bumper {
         addModifiedFile(info, 'package.json')
         return info
       })
+  }
+
+  _publishMonoRepo (info) {
+    return exec(`lerna publish ${info.scope} --yes --no-verify-access`)
+  }
+
+  _getMonoRepoPackagesInfo (info) {
+    return exec('lerna changed --json').then((stdout) => {
+      let json = '[]'
+      if (stdout !== undefined || stdout !== '') {
+        json = stdout
+      }
+      return {packagesInfo: JSON.parse(json), info}
+    })
+  }
+
+  /**
+   * Maybe prepend the changelog text from the PrInfo into the CHANGELOG.md file (unless there was no bump)
+   * @param {PrInfo} info - the pr info
+   * @param {Object} packagesInfo - the package information (name, version, private, location)
+   * @returns {Promise} - a promise resolved when changelog has been prepended
+   */
+  _maybePrependChangelogMonoRepo (info, packagesInfo = []) {
+    if (!this.config.isEnabled('changelog')) {
+      logger.log('Skipping prepending changelog because of config option.')
+      return Promise.resolve(info)
+    }
+
+    if (info.scope === 'none') {
+      logger.log('Skipping prepending changelog because of "none" scope.')
+      return Promise.resolve(info)
+    }
+
+    const dateString = this._getChangelogTextDate()
+
+    const promises = packagesInfo.map(packageInfo => {
+      const data = this._getChangelogText(packageInfo.version, dateString, info.changelog)
+
+      const filename = `packages/${packageInfo.name}/${this.config.features.changelog.file}`
+      return prepend(filename, data)
+        .then(() => {
+          addModifiedFile(info, filename)
+          return info
+        })
+    })
+
+    return Promise.all(promises)
+  }
+
+  _getChangelogTextDate () {
+    const now = new Date()
+    return now.toISOString().split('T').slice(0, 1).join('')
+  }
+
+  _getChangelogText (version, date, changelog) {
+    return `# ${version} (${date})\n${changelog}\n\n`
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,10 +25,11 @@ class Cli {
    * Run the specified command
    * @param {String} cmd - the command to run
    * @param {Boolean} [skipComments] - true if the command line options specified we need to skip pr comments
+   * @param {Boolean} [isMonoRepo] - true if the command line options specified we are in a mono-repo
    * @returns {Promise} a promise resolved when command finishes, or rejected with failure
    */
   // eslint-disable-next-line complexity
-  run (cmd, skipComments) {
+  run (cmd, skipComments, isMonoRepo = false) {
     const config = utils.getConfig()
     if (skipComments) {
       __.set(config, 'features.comments.enabled', false)
@@ -37,14 +38,20 @@ class Cli {
     const ci = this._getCi(config, vcs)
     const bumper = this._getBumper({ci, config, vcs})
 
-    if (cmd === 'bump') {
-      return bumper.bump()
-    } else if (cmd === 'check') {
-      return bumper.check()
-    } else if (cmd === 'check-coverage') {
-      return bumper.checkCoverage()
-    } else if (cmd === 'prepend-changelog') {
-      return bumper.prependChangelog()
+    if (isMonoRepo) {
+      if (cmd === 'bump') {
+        return bumper.bumpMonoRepo()
+      } else if (cmd === 'check') {
+        return bumper.check()
+      }
+    } else {
+      if (cmd === 'bump') {
+        return bumper.bump()
+      } else if (cmd === 'check') {
+        return bumper.check()
+      } else if (cmd === 'check-coverage') {
+        return bumper.checkCoverage()
+      }
     }
 
     return Promise.reject(`Invalid command: ${cmd}`) // eslint-disable-line prefer-promise-reject-errors

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "sinon-chai": "^2.11.0"
   },
   "pr-bumper": {
-    "coverage": 91
+    "coverage": 80
   }
 }


### PR DESCRIPTION
# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [ ] #minor#
- [x] #major#

# CHANGELOG
* Add a new option to support mono repositories. It's now possible to do `check --mono-repo` or `bump --mono-repo`.