### PR TITLE
Prepend changelog was using the wrong path

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,7 +12,8 @@ program
   .version(pkgJson.version)
   .option('-s, --skip-comments', 'disable PR comments even if enabled via .pr-bumper.json')
   .option('-p, --packages-info <packages>',
-          'packages info in json format (useful for prepend-changelog on mono-repo')
+          'packages info in json format. Example: ' +
+          '')
   .arguments('<cmd> ')
   .action((cmd, program) => {
     cli
@@ -37,7 +38,9 @@ program
     console.log(
       '    --skip-comments - disable PR comments even if enabled via .pr-bumper.json\n' +
       '                      Useful particularly when running check-coverage manually\n' +
-      '    --packages-info - packages info in json format (useful for prepend-changelog)'
+      '    --packages-info - packages info in json format (useful only for prepend-changelog)\n' +
+      '                      Example: ' +
+      '[{"name":"repo-package","version":"0.0.0","private":false,location":"/packages/repo-package"}'
     )
     console.log('')
     console.log('  Commands:')
@@ -45,8 +48,8 @@ program
     console.log('    check - verify an open PR has a version-bump comment')
     console.log('    check-coverage - compare current code coverage against baseline from package.json')
     console.log('    bump - actually bump the version based on the merged PR')
-    console.log('    prepend-changelog - Prepend changelog. Must provide the packages info json.')
-    console.log('                       (--packages-info <packages>)')
+    console.log('    prependChangelog - Prepend changelogs of all packages. Useful for mono-repos.')
+    console.log('                       Must provide the packages info as json. (--packages-info <packages>)')
     console.log('    get-merged-pr-scope - get the merged pr scope')
     console.log('')
   })

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -147,14 +147,13 @@ class Bumper {
    * @returns {Promise} a promise resolved with the results of the push
    */
   async prependChangelog (packagesJson) {
-    return Promise.reject(packagesJson)
-    // const packagesInfo = this._parsePackagesInfo(packagesJson)
-    // let info = await this._getMergedPrInfo()
-    // info = await this._maybePrependChangelogForPackages(info, packagesInfo)
-    // info = await this._maybeCommitChanges(info, true)
-    // info = await this._maybePushChanges(info)
-    // info = await this._maybeLogChanges(info)
-    // return info
+    const packagesInfo = this._parsePackagesInfo(packagesJson)
+    let info = await this._getMergedPrInfo()
+    info = await this._maybePrependChangelogForPackages(info, packagesInfo)
+    info = await this._maybeCommitChanges(info, true)
+    info = await this._maybePushChanges(info)
+    info = await this._maybeLogChanges(info)
+    return info
 
     // return this._getMergedPrInfo()
     // .then((info) => {
@@ -614,19 +613,21 @@ class Bumper {
 
     const dateString = this._getChangelogTextDate()
 
-    const {filenames, promises} = packagesInfo.reduce(({promises, filenames}, packageInfo) => {
+    const {paths, promises} = packagesInfo.reduce(({promises, paths}, packageInfo) => {
       const data = this._getChangelogText(packageInfo.version, dateString, info.changelog)
 
-      const filename = packageInfo.location.replace(/[a-zA-Z/@].*packages\//gi, 'packages/')
+      const dir = packageInfo.location.replace(/[a-zA-Z/@].*packages\//gi, 'packages/')
+      const filename = this.config.features.changelog.file
+      const path = `${dir}/${filename}`
 
-      promises.push(prepend(filename, data))
-      filenames.push(filename)
+      promises.push(prepend(path, data))
+      paths.push(path)
 
-      return {filenames, promises}
-    }, {promises: [], filenames: []})
+      return {paths, promises}
+    }, {promises: [], paths: []})
 
     return Promise.all(promises).then(() => {
-      addModifiedFiles(info, filenames)
+      addModifiedFiles(info, paths)
       return info
     })
   }

--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -36,6 +36,12 @@ function addModifiedFile (info, filename) {
   }
 }
 
+/**
+ * Adds the a list of files to info.modifiedFiles if it doesn't already exist
+ * @param {PrInfo} info - the info for the PR
+ * @param {String[]} info.modifiedFiles - the list of modified files so far
+ * @param {String} filenames - the filenames to add to info.modifiedFiles if it's not already there
+ */
 function addModifiedFiles (info, filenames) {
   filenames.forEach(filename => {
     addModifiedFile(info, filename)
@@ -142,7 +148,7 @@ class Bumper {
   }
 
   /**
-   * Prepend the changelogs
+   * Prepend the changelogs of all the packages.
    * @param {String} packagesJson - the package info in json format. Could be empty.
    * @returns {Promise} a promise resolved with the results of the push
    */
@@ -154,23 +160,6 @@ class Bumper {
     info = await this._maybePushChanges(info)
     info = await this._maybeLogChanges(info)
     return info
-
-    // return this._getMergedPrInfo()
-    // .then((info) => {
-    //   return this._maybePrependChangelogForPackages(info, packagesInfo)
-    // })
-    // .then((info) => {
-    //   if (info.e) {
-    //     return Promise.reject(info.e)
-    //   }
-    //   return this._maybeCommitChanges(info, true)
-    // })
-    // .then((info) => {
-    //   return this._maybePushChanges(info)
-    // })
-    // .then((info) => {
-    //   return this._maybeLogChanges(info)
-    // })
   }
 
   /**
@@ -378,10 +367,10 @@ class Bumper {
   /**
    * Commit the changed files that were modified by pr-bumper
    * @param {PrInfo} info - the info for the PR being bumped
-   * @param {Boolean} isChangelogOnlyModified - true if we are only committing the changelog
+   * @param {Boolean} isOnlyChangelogModified - true if we are only committing the changelog
    * @returns {Promise} - a promise resolved with the results of the git commands
    */
-  _maybeCommitChanges (info, isChangelogOnlyModified = false) {
+  _maybeCommitChanges (info, isOnlyChangelogModified = false) {
     if (info.modifiedFiles.length === 0) {
       logger.log('Skipping commit because no files were changed.')
       return Promise.resolve(info)
@@ -397,7 +386,7 @@ class Bumper {
         // Currently there are only two reasons we'll have a commit 1) we have a "none" bump with coverage
         // change, or 2) we have a legit bump commit
         let msg = `Automated version bump to ${info.version}`
-        if (isChangelogOnlyModified) {
+        if (isOnlyChangelogModified) {
           msg = 'Automated changelog prepend'
         } else if (info.scope === 'none') {
           msg = 'Automated code coverage update'
@@ -595,7 +584,8 @@ class Bumper {
   }
 
   /**
-   * Maybe prepend the changelog text from the PrInfo into the CHANGELOG.md file (unless there was no bump)
+   * Maybe prepend the changelog text from the PrInfo into the CHANGELOG.md file for every packages
+   * (unless there was no bump).
    * @param {PrInfo} info - the pr info
    * @param {Object} packagesInfo - the package information (name, version, private, location)
    * @returns {Promise} - a promise resolved when changelog has been prepended
@@ -616,6 +606,7 @@ class Bumper {
     const {paths, promises} = packagesInfo.reduce(({promises, paths}, packageInfo) => {
       const data = this._getChangelogText(packageInfo.version, dateString, info.changelog)
 
+      // We are assuming that all the packages CHANGELOG are under `packages/<package name>/<changelog file>`
       const dir = packageInfo.location.replace(/[a-zA-Z/@].*packages\//gi, 'packages/')
       const filename = this.config.features.changelog.file
       const path = `${dir}/${filename}`
@@ -632,11 +623,22 @@ class Bumper {
     })
   }
 
+  /**
+   * Returns formatted date.
+   * @returns {String} formatted date.
+   */
   _getChangelogTextDate () {
     const now = new Date()
     return now.toISOString().split('T').slice(0, 1).join('')
   }
 
+  /**
+   * Returns changelog text.
+   * @param {String} version - the package version
+   * @param {String} date - the date
+   * @param {String} changelog - the changelog content
+   * @returns {String} formatted
+   */
   _getChangelogText (version, date, changelog) {
     return `# ${version} (${date})\n${changelog}\n\n`
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "sinon-chai": "^2.11.0"
   },
   "pr-bumper": {
-    "coverage": 89.64
+    "coverage": 80
   }
 }


### PR DESCRIPTION
# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

# CHANGELOG
* Prepend changelog was using the wrong path.
* Add comments, improve cli documentation and reduce coverage until I'm adding tests.