### PR TITLE
Add tests and move from async functions to promises

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -217,25 +217,34 @@ class Bumper {
    * @param {String} packagesJson - the package info in json format. Could be empty.
    * @returns {Promise} a promise resolved with the results of the push
    */
-  async prependChangelog (packagesJson) {
+  prependChangelog (packagesJson) {
+    if (__.get(this.config, 'computed.ci.isPr')) {
+      logger.log('Not a merge build, skipping bump')
+      return Promise.resolve()
+    }
+
     const packagesInfo = this._parsePackagesInfo(packagesJson)
-    let info = await this._getMergedPrInfo()
-    info = await this._maybePrependChangelogForPackages(info, packagesInfo)
-    info = await this._maybeCommitChanges(info, true)
-    info = await this._maybePushChanges(info)
-    info = await this._maybeLogChanges(info)
-    return info
+
+    return this._getMergedPrInfo().then(info => {
+      return this._maybePrependChangelogForPackages(info, packagesInfo)
+    }).then(info => {
+      return this._maybeCommitChanges(info, true)
+    }).then(info => {
+      return this._maybePushChanges(info)
+    }).then(info => {
+      return this._maybeLogChanges(info)
+    })
   }
 
   /**
    * Get the last merge commit hash.
    * @returns {Promise} last merge commit hash.
    */
-  async getLastMergeCommitHash () {
-    const mergeCommit = await this._getLastMergeCommit()
+  getLastMergeCommitHash () {
     // Get the commit hash
-    const commitHash = mergeCommit.match(/(\w*) Merge pull request #/)[1]
-    return Promise.resolve(commitHash)
+    return this._getLastMergeCommit().then(mergeCommit => {
+      return Promise.resolve(mergeCommit.match(/(\w*) Merge pull request #/)[1])
+    })
   }
 
   // = Private Methods ==================================================================
@@ -275,18 +284,20 @@ class Bumper {
    * Get the last merge commit.
    * @returns {Promise} the last merge commit.
    */
-  async _getLastMergeCommit () {
-    const stdout = await exec('git log -10 --oneline')
-    // the --oneline format for `git log` puts each commit on a single line, with the hash and then
-    // the commit message, so we first split on \n to get an array of commits
-    const commits = stdout.split('\n')
+  _getLastMergeCommit () {
+    return exec('git log -10 --oneline').then(stdout => {
+      // the --oneline format for `git log` puts each commit on a single line, with the hash and then
+      // the commit message, so we first split on \n to get an array of commits
+      const commits = stdout.split('\n')
 
-    // The commit that represents the merging of the PR will include the text 'pull request #' so
-    // we find that one
-    const mergeCommit = __.find(commits, (commit) => {
-      return commit.match('pull request #') !== null
+      // The commit that represents the merging of the PR will include the text 'pull request #' so
+      // we find that one
+      const mergeCommit = __.find(commits, (commit) => {
+        return commit.match('pull request #') !== null
+      })
+
+      return Promise.resolve(mergeCommit)
     })
-    return Promise.resolve(mergeCommit)
   }
 
   /**
@@ -644,10 +655,10 @@ class Bumper {
 
   /**
    * Returns formatted date.
+   * @param {Date} now current date
    * @returns {String} formatted date.
    */
-  _getChangelogTextDate () {
-    const now = new Date()
+  _getChangelogTextDate (now = new Date()) {
     return now.toISOString().split('T').slice(0, 1).join('')
   }
 


### PR DESCRIPTION
# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

# CHANGELOG
* Add tests and move from async functions to promises