### PR TITLE
Fix bitbucket 7

### DIFF
--- a/lib/bumper.js
+++ b/lib/bumper.js
@@ -243,7 +243,7 @@ class Bumper {
   getLastMergeCommitHash () {
     // Get the commit hash
     return this._getLastMergeCommit().then(mergeCommit => {
-      return Promise.resolve(mergeCommit.match(/(\w*) Merge pull request #/)[1])
+      return Promise.resolve(mergeCommit.match(/(\w*) (Merge ){0,1}pull request #/i)[1])
     })
   }
 
@@ -273,7 +273,7 @@ class Bumper {
   _getLastPr () {
     return this._getLastMergeCommit().then((mergeCommit) => {
       // Get the number from the PR commit
-      const prNumber = mergeCommit.match(/pull request #(\d*)/)[1]
+      const prNumber = mergeCommit.match(/pull request #(\d*)/i)[1]
 
       logger.log(`Fetching PR [${prNumber}]`)
       return this.vcs.getPr(prNumber)
@@ -293,7 +293,7 @@ class Bumper {
       // The commit that represents the merging of the PR will include the text 'pull request #' so
       // we find that one
       const mergeCommit = __.find(commits, (commit) => {
-        return commit.match('pull request #') !== null
+        return commit.match(/pull request #/i) !== null
       })
 
       return Promise.resolve(mergeCommit)


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome

# CHANGELOG

* Fix pr-bumper compatibility with bitbucket 7 new merging